### PR TITLE
Fix bug in `cadflow` from changing ODA version

### DIFF
--- a/docker/cadflow/Makefile
+++ b/docker/cadflow/Makefile
@@ -1,7 +1,14 @@
 # -------- settings --------
 DOCKER        ?= docker
-COMPOSE       ?= docker compose
+COMPOSE       ?= docker compose --env-file config/oda.env
 BUILDER       ?= cadflow-builder
+
+# ODA File Converter package selection
+-include config/oda.env
+ODA_VER       ?=
+ODA_DEB_URL   ?=
+ODA_SHA256    ?=
+export ODA_VER ODA_DEB_URL ODA_SHA256
 
 # Images
 CONVERT_IMG   ?= cadflow-convert:oda-amd64
@@ -14,6 +21,7 @@ PLAT_PROCESS  ?= linux/amd64
 # Host user for file ownership on bind mounts
 UID           := $(shell id -u)
 GID           := $(shell id -g)
+export UID GID
 
 # Paths (relative to repo root)
 IN_DIR        ?= $(CURDIR)/in
@@ -22,12 +30,13 @@ OUT_DIR       ?= $(CURDIR)/out
 
 # -------- targets --------
 .PHONY: help builder-init builder-use build-converter build-processor build-all \
-        up down logs ps clean clean-builders clean-cache dirs up down \
+        up down logs ps clean clean-builders clean-cache dirs oda-config up down \
 		run-converter run-processor
 help:
 	@echo "Targets:"
 	@echo "  builder-init     Initialise QEMU and a docker-container Buildx builder"
 	@echo "  build-converter  Build converter image (DWG->DXF) locally"
+	@echo "  oda-config       Show ODA converter package configuration"
 	@echo "  build-processor  Build processor image (DXF->GPKG/SHP) locally"
 	@echo "  build-all        Build both images"
 	@echo "  up               Run full pipeline via docker compose"
@@ -59,6 +68,9 @@ builder-use:
 build-converter: dirs
 	$(DOCKER) buildx build \
 	  --platform $(PLAT_CONVERT) \
+	  --build-arg ODA_VER="$(ODA_VER)" \
+	  --build-arg ODA_DEB_URL="$(ODA_DEB_URL)" \
+	  --build-arg ODA_SHA256="$(ODA_SHA256)" \
 	  -t $(CONVERT_IMG) \
 	  --load \
 	  ./converter
@@ -84,6 +96,10 @@ logs:
 ps:
 	$(COMPOSE) ps
 
+oda-config:
+	@echo "ODA_VER=$(ODA_VER)"
+	@echo "ODA_DEB_URL=$(ODA_DEB_URL)"
+	@echo "ODA_SHA256=$(ODA_SHA256)"
 
 # Run only the converter stage
 run-converter: dirs

--- a/docker/cadflow/README.md
+++ b/docker/cadflow/README.md
@@ -54,6 +54,31 @@ This performs:
 make builder-use
 ```
 
+## ODA File Converter version
+
+The converter image reads the ODA package selection from:
+
+> config/oda.env
+
+By default this contains:
+
+```dotenv
+ODA_VER=27.1
+ODA_DEB_URL=
+ODA_SHA256=
+```
+
+`ODA_VER` is used to construct the standard ODA guestfiles download URL. Set
+`ODA_DEB_URL` only if ODA changes its filename pattern or you need to point at a
+specific package URL. `ODA_SHA256` is optional, but recommended for reproducible
+builds.
+
+You can inspect the active values with:
+
+```bash
+make oda-config
+```
+
 ### Build all images
 
 ```bash
@@ -90,13 +115,13 @@ Place input drawings in:
 ### Execute the full conversion pipeline
 
 ```bash
-docker compose up
+make up
 ```
 
-or
+To call Compose directly, pass the CADFlow config env file:
 
 ```bash
-make up
+docker compose --env-file config/oda.env up
 ```
 
 The converter outputs `.dxf` files to `work/`.
@@ -202,6 +227,11 @@ Ctrl+C, or `--abort-on-container-exit` behaviour).
 
 ```text
 cadflow/
+├── config/
+│   ├── oda.env                    ODA package version/URL for converter builds
+│   ├── default_filters.yml          (optional)
+│   ├── blank_filters.yml            (optional)
+│   └── <drawing_name>.yml           (optional per-drawing)
 ├── converter/
 │   ├── Dockerfile
 │   └── run_convert.sh
@@ -210,10 +240,6 @@ cadflow/
 │   ├── run_conversion.py
 │   ├── run_process.sh
 │   └── utils.py
-├── config/
-│   ├── default_filters.yml          (optional)
-│   ├── blank_filters.yml            (optional)
-│   └── <drawing_name>.yml           (optional per-drawing)
 ├── in/
 ├── work/
 ├── out/

--- a/docker/cadflow/compose.yaml
+++ b/docker/cadflow/compose.yaml
@@ -2,6 +2,10 @@ services:
   convert:
     build:
       context: ./converter
+      args:
+        ODA_VER: ${ODA_VER}
+        ODA_DEB_URL: ${ODA_DEB_URL:-}
+        ODA_SHA256: ${ODA_SHA256:-}
     image: cadflow-convert:oda-amd64
     platform: linux/amd64
     environment:

--- a/docker/cadflow/config/README.md
+++ b/docker/cadflow/config/README.md
@@ -1,0 +1,34 @@
+# CADFlow configuration
+
+## ODA File Converter package
+
+`oda.env` controls which ODA File Converter package is used when building the
+converter image.
+
+```dotenv
+ODA_VER=27.1
+ODA_DEB_URL=
+ODA_SHA256=
+```
+
+- `ODA_VER` is used to construct the standard ODA guestfiles URL.
+- `ODA_DEB_URL` overrides the constructed URL when set.
+- `ODA_SHA256` is optional, but should be set for reproducible builds.
+
+The standard URL pattern is:
+
+```text
+https://www.opendesign.com/guestfiles/get?filename=ODAFileConverter_QT6_lnxX64_8.3dll_${ODA_VER}.deb
+```
+
+Update `ODA_VER` when ODA publishes a newer package. If ODA changes its filename
+pattern, leave `ODA_VER` as documentation and set `ODA_DEB_URL` explicitly.
+
+## Drawing filters
+
+Drawing-specific processor configuration can also be placed in this directory:
+
+1. `<drawing_stem>.yml`
+2. `<drawing_stem>.yaml`
+3. `default_filters.yml`
+4. `blank_filters.yml`

--- a/docker/cadflow/config/oda.env
+++ b/docker/cadflow/config/oda.env
@@ -1,0 +1,7 @@
+# ODA File Converter package selection.
+#
+# Update ODA_VER when ODA publishes a newer package.
+
+ODA_VER=27.1
+ODA_DEB_URL=
+ODA_SHA256=

--- a/docker/cadflow/converter/Dockerfile
+++ b/docker/cadflow/converter/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stable-slim
 
-ARG ODA_VER=26.10
-ARG ODA_DEB_URL="https://www.opendesign.com/guestfiles/get?filename=ODAFileConverter_QT6_lnxX64_8.3dll_${ODA_VER}.deb"
+ARG ODA_VER
+ARG ODA_DEB_URL=""
 ARG ODA_SHA256=""
 
 # Runtime deps: Xvfb headless X, OpenGL/X11/XCB stack, Mesa software GL, image libs, fonts
@@ -19,17 +19,35 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-dejavu-core \
  && rm -rf /var/lib/apt/lists/*
 
-# Fetch and lay out ODA File Converter
+# Fetch and lay out ODA File Converter.
+#
+# ODA_VER is normally supplied from config/oda.env via the Makefile/Compose.
+# ODA_DEB_URL can be supplied to override the standard ODA guestfiles URL.
 RUN set -eux; \
-    curl -fsSL "$ODA_DEB_URL" -o /tmp/odafc.deb; \
+    if [ -z "$ODA_DEB_URL" ]; then \
+      if [ -z "$ODA_VER" ]; then \
+        echo "Either ODA_VER or ODA_DEB_URL must be supplied." >&2; \
+        echo "Set ODA_VER in config/oda.env, or pass ODA_DEB_URL as a build argument." >&2; \
+        exit 1; \
+      fi; \
+      ODA_DEB_URL="https://www.opendesign.com/guestfiles/get?filename=ODAFileConverter_QT6_lnxX64_8.3dll_${ODA_VER}.deb"; \
+    fi; \
+    echo "Downloading ODA File Converter from: $ODA_DEB_URL"; \
+    curl -fL "$ODA_DEB_URL" -o /tmp/odafc.deb; \
     if [ -n "$ODA_SHA256" ]; then echo "${ODA_SHA256}  /tmp/odafc.deb" | sha256sum -c -; fi; \
-    dpkg-deb -x /tmp/odafc.deb /opt/odafc-unpack; \
-    install -d /opt/oda-file-converter; \
-    srcdir="$(dirname "$(find /opt/odafc-unpack -type f -name ODAFileConverter -print -quit)")"; \
-    cp -a "${srcdir}/." /opt/oda-file-converter/; \
-    ln -sf /opt/oda-file-converter/ODAFileConverter /usr/local/bin/oda-file-converter; \
-    ln -sf /usr/local/bin/oda-file-converter /usr/local/bin/TeighaFileConverter; \
-    rm -rf /opt/odafc-unpack /tmp/odafc.deb
+    dpkg-deb -x /tmp/odafc.deb /; \
+    real_bin="$(find /usr/bin -type f -path '*/ODAFileConverter_*/*' -name ODAFileConverter -print -quit)"; \
+    if [ -z "$real_bin" ]; then \
+      echo "Could not find real ODAFileConverter binary under /usr/bin/ODAFileConverter_*" >&2; \
+      echo "Found candidates:" >&2; \
+      find /usr -name ODAFileConverter -o -name 'ODAFileConverter_*' >&2; \
+      exit 1; \
+    fi; \
+    chmod +x "$real_bin"; \
+    ln -sf "$real_bin" /usr/local/bin/oda-file-converter; \
+    ln -sf "$real_bin" /usr/local/bin/TeighaFileConverter; \
+    rm -f /tmp/odafc.deb; \
+    ls -l /usr/local/bin/oda-file-converter
 
 # TIFF compatibility shim (Qt plugin expects .5, Debian ships .6)
 RUN set -eux; \


### PR DESCRIPTION
## Summary

This PR makes the ODA File Converter setup in `docker/cadflow` easier to maintain and fixes the converter image layout issue that caused the ODA launcher to fail at runtime.

The main change is to move ODA version configuration out of the converter Dockerfile and into a dedicated config file, while keeping the existing `make up` workflow intact.

## Motivation

The previous Dockerfile copied the first directory containing a file named `ODAFileConverter`. In newer ODA packages, this may select a launcher script rather than the actual binary. That launcher expects the real executable to exist under a versioned path such as:

```text
/usr/bin/ODAFileConverter_27.1.0.0/ODAFileConverter
```

Because the previous image layout did not preserve that package structure, the converter failed at runtime with:

```text
/usr/local/bin/oda-file-converter: 2: /usr/bin/ODAFileConverter_27.1.0.0/ODAFileConverter: not found
```

This PR preserves the ODA package layout and links directly to the real executable.

## Changes

* Added `config/oda.env` for ODA configuration:

  * `ODA_VER`
  * `ODA_DEB_URL`
  * `ODA_SHA256`

* Updated `converter/Dockerfile` to:

  * accept ODA configuration via build args;
  * construct the default ODA download URL from `ODA_VER`;
  * allow `ODA_DEB_URL` to override the constructed URL;
  * optionally verify the downloaded `.deb` using `ODA_SHA256`;
  * unpack the ODA `.deb` into `/` so the package’s expected `/usr/bin/ODAFileConverter_*` layout is preserved;
  * symlink `/usr/local/bin/oda-file-converter` and `/usr/local/bin/TeighaFileConverter` directly to the real ODA executable.

* Updated the `Makefile` to:

  * include `config/oda.env`;
  * pass ODA build arguments through to the converter image build;
  * keep existing commands such as `make up` working;
  * add `make oda-config` for checking the active ODA configuration.

* Updated `compose.yaml` to pass ODA build args to the converter service.

* Updated documentation in `README.md` and `config/README.md`.
