### PR TITLE
Add codecov badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AMR-Hub Project
 
+[![codecov](https://codecov.io/gh/UCL-ARC/amr-hub/branch/as/codecov/graph/badge.svg)](https://codecov.io/gh/UCL-ARC/amr-hub)
+
 Welcome to the AMR-Hub Project. We aim to model the transmission of Anti-Microbial Resistance in Hospitals.
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->


### PR DESCRIPTION
We can display the results of the codecov as a badge in the README. The implementation in this PR currently points to the branch `as/codecov` as that is the branch for which the codecov workflow has been run but we can configure it to show codecov for `main`.