### PR TITLE
Update floorplan extraction workflow

### DIFF
--- a/examples/floorplan_extraction.py
+++ b/examples/floorplan_extraction.py
@@ -74,20 +74,32 @@ def plot_extracted_floorplan(
     )
 
     if door_column is not None and door_column in production_gdf.columns:
-        for door_segments in production_gdf[door_column]:
-            for x1, y1, x2, y2 in door_segments:
-                ax.plot(
-                    [x1, x2],
-                    [y1, y2],
-                    color="#7c2d12",
-                    linewidth=1.2,
-                    label="_nolegend_",
-                )
+        door_label = "Canonical door opening"
+        for x1, y1, x2, y2 in _unique_door_segments(production_gdf[door_column]):
+            ax.plot(
+                [x1, x2],
+                [y1, y2],
+                color="white",
+                linewidth=3.6,
+                solid_capstyle="butt",
+                label="_nolegend_",
+                zorder=4,
+            )
+            ax.plot(
+                [x1, x2],
+                [y1, y2],
+                color="#dc2626",
+                linewidth=2.0,
+                solid_capstyle="butt",
+                label=door_label,
+                zorder=5,
+            )
+            door_label = "_nolegend_"
 
-    _plot_shared_wall_diagnostics(
-        ax,
-        production_gdf.attrs.get("shared_wall_detection"),
-    )
+    # _plot_shared_wall_diagnostics(
+    #     ax,
+    #     production_gdf.attrs.get("shared_wall_detection"),
+    # )
 
     for _, row in production_gdf.iterrows():
         label_point = row.geometry.representative_point()
@@ -106,10 +118,35 @@ def plot_extracted_floorplan(
     ax.set_ylim(min_y - margin, max_y + margin)
     ax.set_aspect("equal", adjustable="box")
     ax.set_axis_off()
+    handles, labels = ax.get_legend_handles_labels()
+    unique = dict(zip(labels, handles, strict=False))
+    if unique:
+        ax.legend(unique.values(), unique.keys(), loc="upper right", fontsize=7)
     fig.tight_layout()
     output_path.parent.mkdir(parents=True, exist_ok=True)
     fig.savefig(output_path, dpi=200)
     plt.close(fig)
+
+
+def _unique_door_segments(door_values):
+    """Return canonical door segments once, including doors shared by two rooms."""
+    segments = {}
+
+    for room_doors in door_values:
+        for x1, y1, x2, y2 in room_doors:
+            start = (float(x1), float(y1))
+            end = (float(x2), float(y2))
+            key = tuple(
+                sorted(
+                    (
+                        (round(start[0], 8), round(start[1], 8)),
+                        (round(end[0], 8), round(end[1], 8)),
+                    )
+                )
+            )
+            segments.setdefault(key, (*start, *end))
+
+    return segments.values()
 
 
 def _plot_shared_wall_diagnostics(

--- a/examples/floorplan_extraction.py
+++ b/examples/floorplan_extraction.py
@@ -7,6 +7,7 @@ Note that data paths and config paths are dummies.
 import logging
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import yaml
 from floorplan_extractor.dxf_polygon_extraction import (
     config_from_yaml,
@@ -23,11 +24,47 @@ logger = logging.getLogger(__name__)
 register_yaml_representers()
 
 
+def plot_extracted_floorplan(
+    production_gdf,
+    *,
+    room_name_column: str,
+    door_column: str | None,
+    output_path: Path,
+) -> None:
+    """Plot extracted room polygons and door segments to a static image."""
+    fig, ax = plt.subplots(figsize=(12, 10))
+
+    production_gdf.boundary.plot(ax=ax, color="black", linewidth=0.6)
+
+    if door_column is not None and door_column in production_gdf.columns:
+        for door_segments in production_gdf[door_column]:
+            for x1, y1, x2, y2 in door_segments:
+                ax.plot([x1, x2], [y1, y2], color="brown", linewidth=1.2)
+
+    for _, row in production_gdf.iterrows():
+        label_point = row.geometry.representative_point()
+        ax.text(
+            label_point.x,
+            label_point.y,
+            str(row[room_name_column]),
+            fontsize=4,
+            ha="center",
+            va="center",
+        )
+
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_axis_off()
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=200)
+    plt.close(fig)
+
+
 def main() -> None:
     """Run main routine."""
     data_path = Path("floorplan.dxf")
     config_path = Path("./config.yaml")
     output_path = Path("./output.yaml")
+    plot_path = output_path.with_suffix(".png")
 
     pec = config_from_yaml(config_path)
 
@@ -39,13 +76,21 @@ def main() -> None:
     review_gdf = gdf.loc[gdf["needs_review"], :]
 
     if len(review_gdf) > 0:
-        logger.warn(f"Identified {len(review_gdf)} rooms for review")
-        logger.warn(review_gdf.head())
+        logger.warning("Identified %s rooms for review", len(review_gdf))
+        logger.warning(review_gdf.head())
 
     rooms = polygons_to_rooms(
         production_gdf,
         room_name_column=pec.polygons.polygon_label_target,
         door_column=pec.doors.out_col if pec.doors else None,
+    )
+
+    logger.info("Writing floorplan plot to %s", plot_path)
+    plot_extracted_floorplan(
+        production_gdf,
+        room_name_column=pec.polygons.polygon_label_target,
+        door_column=pec.doors.out_col if pec.doors else None,
+        output_path=plot_path,
     )
 
     logger.info("Converting rooms to yaml")

--- a/examples/floorplan_extraction.py
+++ b/examples/floorplan_extraction.py
@@ -1,11 +1,11 @@
-"""
-Example usage of polygon extraction process.
+"""Run DXF floorplan extraction and write YAML plus diagnostics."""
 
-Note that data paths and config paths are dummies.
-"""
-
+import argparse
 import logging
+import os
 from pathlib import Path
+
+os.environ.setdefault("MPLCONFIGDIR", "/tmp/matplotlib")
 
 import matplotlib.pyplot as plt
 import yaml
@@ -13,15 +13,46 @@ from floorplan_extractor.dxf_polygon_extraction import (
     config_from_yaml,
     extract_polygons,
 )
+from floorplan_extractor.shared_walls import (
+    SharedWallDetectionResult,
+    candidate_midline,
+    rejection_overlap_lines,
+)
 from floorplan_extractor.yaml_construction import (
     build_yaml_structure,
     polygons_to_rooms,
     register_yaml_representers,
 )
 
+DEFAULT_DXF_PATH = Path("floorplan.dxf")
+DEFAULT_CONFIG_PATH = Path("config.yaml")
+DEFAULT_OUTPUT_PATH = Path("output.yaml")
+DEFAULT_DIAGNOSTIC_PATH = Path("output_diagnostic.png")
+DEFAULT_BUILDING_NAME = "Sample Hospital"
+DEFAULT_BUILDING_ADDRESS = "123 Health St, Wellness City"
+DEFAULT_FLOOR_LEVEL = 0
+MAX_REJECTION_MARKERS = 50
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 register_yaml_representers()
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for the local extraction example."""
+    parser = argparse.ArgumentParser(
+        description="Extract room polygons from a DXF floorplan.",
+    )
+    parser.add_argument("--dxf", type=Path, default=DEFAULT_DXF_PATH)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT_PATH)
+    parser.add_argument(
+        "--diagnostic",
+        type=Path,
+        default=DEFAULT_DIAGNOSTIC_PATH,
+    )
+
+    return parser.parse_args()
 
 
 def plot_extracted_floorplan(
@@ -31,15 +62,32 @@ def plot_extracted_floorplan(
     door_column: str | None,
     output_path: Path,
 ) -> None:
-    """Plot extracted room polygons and door segments to a static image."""
+    """Plot rooms, doors, and shared-wall decisions to a static image."""
     fig, ax = plt.subplots(figsize=(12, 10))
 
-    production_gdf.boundary.plot(ax=ax, color="black", linewidth=0.6)
+    production_gdf.plot(
+        ax=ax,
+        facecolor="#d8ecff",
+        edgecolor="#1f2937",
+        linewidth=0.5,
+        alpha=0.35,
+    )
 
     if door_column is not None and door_column in production_gdf.columns:
         for door_segments in production_gdf[door_column]:
             for x1, y1, x2, y2 in door_segments:
-                ax.plot([x1, x2], [y1, y2], color="brown", linewidth=1.2)
+                ax.plot(
+                    [x1, x2],
+                    [y1, y2],
+                    color="#7c2d12",
+                    linewidth=1.2,
+                    label="_nolegend_",
+                )
+
+    _plot_shared_wall_diagnostics(
+        ax,
+        production_gdf.attrs.get("shared_wall_detection"),
+    )
 
     for _, row in production_gdf.iterrows():
         label_point = row.geometry.representative_point()
@@ -52,27 +100,89 @@ def plot_extracted_floorplan(
             va="center",
         )
 
+    min_x, min_y, max_x, max_y = production_gdf.total_bounds
+    margin = max(max_x - min_x, max_y - min_y) * 0.02
+    ax.set_xlim(min_x - margin, max_x + margin)
+    ax.set_ylim(min_y - margin, max_y + margin)
     ax.set_aspect("equal", adjustable="box")
     ax.set_axis_off()
     fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     fig.savefig(output_path, dpi=200)
     plt.close(fig)
 
 
+def _plot_shared_wall_diagnostics(
+    ax,
+    detection: object,
+) -> None:
+    if not isinstance(detection, SharedWallDetectionResult):
+        return
+
+    accepted_label = "Accepted shared wall"
+    for candidate in detection.candidates:
+        line = candidate_midline(candidate)
+        x, y = line.xy
+        ax.plot(
+            x,
+            y,
+            color="#16a34a",
+            linewidth=1.6,
+            label=accepted_label,
+        )
+        accepted_label = "_nolegend_"
+
+    rejection_labels = {
+        "ambiguous_match": "Ambiguous shared wall",
+        "normalisation_invalid_geometry": "Rejected: invalid geometry",
+        "rejected": "Rejected shared wall",
+    }
+    for rejection in detection.rejections[:MAX_REJECTION_MARKERS]:
+        if rejection.reason == "ambiguous_match":
+            label_key = "ambiguous_match"
+            colour = "#dc2626"
+            linestyle = "--"
+        elif rejection.reason == "normalisation_invalid_geometry":
+            label_key = "normalisation_invalid_geometry"
+            colour = "#7c3aed"
+            linestyle = ":"
+        else:
+            label_key = "rejected"
+            colour = "#f59e0b"
+            linestyle = "--"
+        label = rejection_labels[label_key]
+        for line in rejection_overlap_lines(rejection):
+            x, y = line.xy
+            ax.plot(
+                x,
+                y,
+                color=colour,
+                linewidth=1.1,
+                linestyle=linestyle,
+                alpha=0.8,
+                label=label,
+            )
+            label = "_nolegend_"
+        rejection_labels[label_key] = "_nolegend_"
+
+    handles, labels = ax.get_legend_handles_labels()
+    unique = dict(zip(labels, handles, strict=False))
+    if unique:
+        ax.legend(unique.values(), unique.keys(), loc="upper right", fontsize=7)
+
+
 def main() -> None:
     """Run main routine."""
-    data_path = Path("floorplan.dxf")
-    config_path = Path("./config.yaml")
-    output_path = Path("./output.yaml")
-    plot_path = output_path.with_suffix(".png")
+    args = parse_args()
 
-    pec = config_from_yaml(config_path)
+    pec = config_from_yaml(args.config)
 
-    gdf = extract_polygons(data_path, pec)
+    gdf = extract_polygons(args.dxf, pec)
 
     logger.info("Extracted %s polygons", len(gdf))
 
-    production_gdf = gdf.loc[gdf["has_label"], :]
+    production_gdf = gdf.loc[gdf["has_label"], :].copy()
+    production_gdf.attrs = dict(gdf.attrs)
     review_gdf = gdf.loc[gdf["needs_review"], :]
 
     if len(review_gdf) > 0:
@@ -85,24 +195,25 @@ def main() -> None:
         door_column=pec.doors.out_col if pec.doors else None,
     )
 
-    logger.info("Writing floorplan plot to %s", plot_path)
+    logger.info("Writing floorplan diagnostic plot to %s", args.diagnostic)
     plot_extracted_floorplan(
         production_gdf,
         room_name_column=pec.polygons.polygon_label_target,
         door_column=pec.doors.out_col if pec.doors else None,
-        output_path=plot_path,
+        output_path=args.diagnostic,
     )
 
     logger.info("Converting rooms to yaml")
     data = build_yaml_structure(
-        building_name="Sample Hospital",
-        building_address="123 Health St, Wellness City",
-        floor_level=0,
+        building_name=DEFAULT_BUILDING_NAME,
+        building_address=DEFAULT_BUILDING_ADDRESS,
+        floor_level=DEFAULT_FLOOR_LEVEL,
         rooms=rooms,
     )
 
-    logger.info("Writing building yaml to %s", output_path)
-    with output_path.open("w", encoding="utf-8") as f:
+    logger.info("Writing building yaml to %s", args.output)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as f:
         yaml.safe_dump(
             data,
             f,

--- a/examples/floorplan_extraction.py
+++ b/examples/floorplan_extraction.py
@@ -35,8 +35,15 @@ def main() -> None:
 
     logger.info("Extracted %s polygons", len(gdf))
 
+    production_gdf = gdf.loc[gdf["has_label"], :]
+    review_gdf = gdf.loc[gdf["needs_review"], :]
+
+    if len(review_gdf) > 0:
+        logger.warn(f"Identified {len(review_gdf)} rooms for review")
+        logger.warn(review_gdf.head())
+
     rooms = polygons_to_rooms(
-        gdf,
+        production_gdf,
         room_name_column=pec.polygons.polygon_label_target,
         door_column=pec.doors.out_col if pec.doors else None,
     )

--- a/examples/floorplan_extraction.py
+++ b/examples/floorplan_extraction.py
@@ -1,4 +1,10 @@
-"""Run DXF floorplan extraction and write YAML plus diagnostics."""
+"""
+Extract a configured DXF floorplan into simulation YAML.
+
+Run this example from the ``python-code`` directory. By default it reads
+``floorplan.dxf`` and ``config.yaml``, then writes ``output.yaml`` and
+``output_diagnostic.png`` in the same directory.
+"""
 
 import argparse
 import logging
@@ -39,17 +45,41 @@ register_yaml_representers()
 
 
 def parse_args() -> argparse.Namespace:
-    """Parse command-line arguments for the local extraction example."""
+    """
+    Parse command-line arguments for the floorplan extraction example.
+
+    Returns
+    -------
+    argparse.Namespace
+        Parsed input, configuration, YAML output, and diagnostic image paths.
+
+    """
     parser = argparse.ArgumentParser(
         description="Extract room polygons from a DXF floorplan.",
     )
-    parser.add_argument("--dxf", type=Path, default=DEFAULT_DXF_PATH)
-    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
-    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT_PATH)
+    parser.add_argument(
+        "--dxf",
+        type=Path,
+        default=DEFAULT_DXF_PATH,
+        help="Input DXF path (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG_PATH,
+        help="Extraction configuration path (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help="Output YAML path (default: %(default)s).",
+    )
     parser.add_argument(
         "--diagnostic",
         type=Path,
         default=DEFAULT_DIAGNOSTIC_PATH,
+        help="Diagnostic image path (default: %(default)s).",
     )
 
     return parser.parse_args()
@@ -62,7 +92,24 @@ def plot_extracted_floorplan(
     door_column: str | None,
     output_path: Path,
 ) -> None:
-    """Plot rooms, doors, and shared-wall decisions to a static image."""
+    """
+    Plot extracted rooms and canonical doors to a static image.
+
+    Door segments are deduplicated because a shared door is attached to both
+    connected rooms in the extracted data.
+
+    Parameters
+    ----------
+    production_gdf : geopandas.GeoDataFrame
+        Labelled room polygons selected for serialisation.
+    room_name_column : str
+        Column containing the room label shown on the plot.
+    door_column : str or None
+        Optional column containing canonical door segments.
+    output_path : pathlib.Path
+        Destination path for the PNG image.
+
+    """
     fig, ax = plt.subplots(figsize=(12, 10))
 
     production_gdf.plot(
@@ -209,7 +256,7 @@ def _plot_shared_wall_diagnostics(
 
 
 def main() -> None:
-    """Run main routine."""
+    """Extract the configured floorplan and write YAML plus diagnostics."""
     args = parse_args()
 
     pec = config_from_yaml(args.config)

--- a/python-code/.gitignore
+++ b/python-code/.gitignore
@@ -170,4 +170,9 @@ _version.py
 
 simulation_outputs/
 ../simulation_outputs/
+
+# Benchmark and profiling artefacts
+benchmarks/results/
 *.prof
+*.pstats
+*.lprof

--- a/python-code/benchmarks/__init__.py
+++ b/python-code/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Standalone performance benchmarks."""

--- a/python-code/benchmarks/shared_wall_detection.py
+++ b/python-code/benchmarks/shared_wall_detection.py
@@ -1,10 +1,10 @@
-"""Measure exhaustive shared-wall candidate detection on synthetic room grids."""
+"""Compare indexed and exhaustive shared-wall detection on synthetic room grids."""
 
 # ruff: noqa: T201
 
 import argparse
 import platform
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from statistics import median
 from time import perf_counter
 
@@ -13,10 +13,17 @@ import shapely
 from shapely.geometry import Polygon
 
 from floorplan_extractor.shared_walls import (
+    REVIEW_REJECTION_REASONS,
     SharedWallConfig,
+    SharedWallDetectionResult,
+    _detect_shared_wall_candidates_exhaustive,
     detect_shared_wall_candidates,
 )
 
+Detector = Callable[
+    [gpd.GeoDataFrame, SharedWallConfig],
+    SharedWallDetectionResult,
+]
 DEFAULT_GRID_SIZES = (4, 8, 12)
 DEFAULT_REPEAT = 3
 DEFAULT_WARMUP = 1
@@ -28,8 +35,8 @@ SEGMENTS_PER_ROOM = 4
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Benchmark exhaustive shared-wall detection using non-sensitive "
-            "synthetic square-room grids."
+            "Compare indexed and exhaustive shared-wall detection using "
+            "non-sensitive synthetic square-room grids."
         )
     )
     parser.add_argument(
@@ -88,6 +95,7 @@ def _room_grid(side_length: int) -> gpd.GeoDataFrame:
 
 
 def _measure(
+    detector: Detector,
     rooms: gpd.GeoDataFrame,
     config: SharedWallConfig,
     *,
@@ -95,17 +103,20 @@ def _measure(
     warmup: int,
 ) -> tuple[float, float, int, int]:
     for _ in range(warmup):
-        detect_shared_wall_candidates(rooms, config)
+        detector(rooms, config)
 
     timings: list[float] = []
     candidate_count = 0
     rejection_count = 0
     for _ in range(repeat):
         start = perf_counter()
-        result = detect_shared_wall_candidates(rooms, config)
+        result = detector(rooms, config)
         timings.append(perf_counter() - start)
         candidate_count = len(result.candidates)
-        rejection_count = len(result.rejections)
+        rejection_count = sum(
+            rejection.reason in REVIEW_REJECTION_REASONS
+            for rejection in result.rejections
+        )
 
     return median(timings), min(timings), candidate_count, rejection_count
 
@@ -133,22 +144,41 @@ def main() -> None:
     print(f"Shapely: {shapely.__version__}")
     print(f"Repeats: {args.repeat}; warm-up runs: {args.warmup}")
     print()
-    print("| Grid | Rooms | Segments | Median (s) | Best (s) | Accepted | Rejected |")
-    print("| ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+    print(
+        "| Grid | Rooms | Segments | Indexed median (s) | "
+        "Exhaustive median (s) | Speed-up | Accepted | Material rejected |"
+    )
+    print("| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
 
     for side_length in args.grid_sizes:
         rooms = _room_grid(side_length)
-        median_seconds, best_seconds, candidates, rejections = _measure(
+        indexed_median, _, indexed_candidates, indexed_rejections = _measure(
+            detect_shared_wall_candidates,
             rooms,
             config,
             repeat=args.repeat,
             warmup=args.warmup,
         )
+        exhaustive_median, _, exhaustive_candidates, exhaustive_rejections = _measure(
+            _detect_shared_wall_candidates_exhaustive,
+            rooms,
+            config,
+            repeat=args.repeat,
+            warmup=args.warmup,
+        )
+        if (indexed_candidates, indexed_rejections) != (
+            exhaustive_candidates,
+            exhaustive_rejections,
+        ):
+            msg = "Indexed and exhaustive material result counts differ"
+            raise RuntimeError(msg)
+
         room_count = len(rooms)
         print(
             f"| {side_length}x{side_length} | {room_count} | "
-            f"{room_count * SEGMENTS_PER_ROOM} | {median_seconds:.6f} | "
-            f"{best_seconds:.6f} | {candidates} | {rejections} |"
+            f"{room_count * SEGMENTS_PER_ROOM} | {indexed_median:.6f} | "
+            f"{exhaustive_median:.6f} | {exhaustive_median / indexed_median:.2f}x | "
+            f"{indexed_candidates} | {indexed_rejections} |"
         )
 
 

--- a/python-code/benchmarks/shared_wall_detection.py
+++ b/python-code/benchmarks/shared_wall_detection.py
@@ -1,0 +1,156 @@
+"""Measure exhaustive shared-wall candidate detection on synthetic room grids."""
+
+# ruff: noqa: T201
+
+import argparse
+import platform
+from collections.abc import Sequence
+from statistics import median
+from time import perf_counter
+
+import geopandas as gpd
+import shapely
+from shapely.geometry import Polygon
+
+from floorplan_extractor.shared_walls import (
+    SharedWallConfig,
+    detect_shared_wall_candidates,
+)
+
+DEFAULT_GRID_SIZES = (4, 8, 12)
+DEFAULT_REPEAT = 3
+DEFAULT_WARMUP = 1
+ROOM_SIZE = 400.0
+ROOM_GAP = 100.0
+SEGMENTS_PER_ROOM = 4
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark exhaustive shared-wall detection using non-sensitive "
+            "synthetic square-room grids."
+        )
+    )
+    parser.add_argument(
+        "--grid-sizes",
+        type=int,
+        nargs="+",
+        default=DEFAULT_GRID_SIZES,
+        help="Grid side lengths to measure (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=DEFAULT_REPEAT,
+        help="Measured runs per input size (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=DEFAULT_WARMUP,
+        help="Warm-up runs per input size (default: %(default)s).",
+    )
+    return parser.parse_args()
+
+
+def _config() -> SharedWallConfig:
+    return SharedWallConfig(
+        enabled=True,
+        min_gap=50.0,
+        max_gap=130.0,
+        angle_tolerance_degrees=2.0,
+        min_overlap_ratio=0.75,
+        min_overlap_length=250.0,
+        canonical_line="midline",
+    )
+
+
+def _room_grid(side_length: int) -> gpd.GeoDataFrame:
+    if side_length < 1:
+        msg = "Grid sizes must be positive integers"
+        raise ValueError(msg)
+
+    stride = ROOM_SIZE + ROOM_GAP
+    polygons = [
+        Polygon(
+            [
+                (column * stride, row * stride),
+                (column * stride + ROOM_SIZE, row * stride),
+                (column * stride + ROOM_SIZE, row * stride + ROOM_SIZE),
+                (column * stride, row * stride + ROOM_SIZE),
+            ]
+        )
+        for row in range(side_length)
+        for column in range(side_length)
+    ]
+    return gpd.GeoDataFrame({"geometry": polygons}, geometry="geometry")
+
+
+def _measure(
+    rooms: gpd.GeoDataFrame,
+    config: SharedWallConfig,
+    *,
+    repeat: int,
+    warmup: int,
+) -> tuple[float, float, int, int]:
+    for _ in range(warmup):
+        detect_shared_wall_candidates(rooms, config)
+
+    timings: list[float] = []
+    candidate_count = 0
+    rejection_count = 0
+    for _ in range(repeat):
+        start = perf_counter()
+        result = detect_shared_wall_candidates(rooms, config)
+        timings.append(perf_counter() - start)
+        candidate_count = len(result.candidates)
+        rejection_count = len(result.rejections)
+
+    return median(timings), min(timings), candidate_count, rejection_count
+
+
+def _validate_args(grid_sizes: Sequence[int], repeat: int, warmup: int) -> None:
+    if any(size < 1 for size in grid_sizes):
+        msg = "All grid sizes must be positive integers"
+        raise ValueError(msg)
+    if repeat < 1:
+        msg = "--repeat must be at least 1"
+        raise ValueError(msg)
+    if warmup < 0:
+        msg = "--warmup cannot be negative"
+        raise ValueError(msg)
+
+
+def main() -> None:
+    """Run the benchmark and print machine details plus a Markdown table."""
+    args = _parse_args()
+    _validate_args(args.grid_sizes, args.repeat, args.warmup)
+    config = _config()
+
+    print(f"Python: {platform.python_version()}")
+    print(f"Platform: {platform.platform()}")
+    print(f"Shapely: {shapely.__version__}")
+    print(f"Repeats: {args.repeat}; warm-up runs: {args.warmup}")
+    print()
+    print("| Grid | Rooms | Segments | Median (s) | Best (s) | Accepted | Rejected |")
+    print("| ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+
+    for side_length in args.grid_sizes:
+        rooms = _room_grid(side_length)
+        median_seconds, best_seconds, candidates, rejections = _measure(
+            rooms,
+            config,
+            repeat=args.repeat,
+            warmup=args.warmup,
+        )
+        room_count = len(rooms)
+        print(
+            f"| {side_length}x{side_length} | {room_count} | "
+            f"{room_count * SEGMENTS_PER_ROOM} | {median_seconds:.6f} | "
+            f"{best_seconds:.6f} | {candidates} | {rejections} |"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/python-code/docs/api/floorplan_dxf_extraction.md
+++ b/python-code/docs/api/floorplan_dxf_extraction.md
@@ -1,0 +1,3 @@
+# DXF Floorplan Extraction
+
+::: floorplan_extractor.dxf_polygon_extraction

--- a/python-code/docs/api/floorplan_shared_walls.md
+++ b/python-code/docs/api/floorplan_shared_walls.md
@@ -1,0 +1,3 @@
+# Shared-Wall Normalisation
+
+::: floorplan_extractor.shared_walls

--- a/python-code/docs/api/floorplan_yaml_construction.md
+++ b/python-code/docs/api/floorplan_yaml_construction.md
@@ -1,0 +1,3 @@
+# Floorplan YAML Construction
+
+::: floorplan_extractor.yaml_construction

--- a/python-code/docs/api/index.md
+++ b/python-code/docs/api/index.md
@@ -17,3 +17,7 @@ This section provides a comprehensive reference for the AMR-Hub API, detailing t
 - [Simulation Factory](simulation_factory.md)
 - [Simulation Dataclass](simulation.md)
 - [Task Dataclass](task.md)
+- Floorplan extraction:
+  - [DXF extraction](floorplan_dxf_extraction.md)
+  - [Shared-wall normalisation](floorplan_shared_walls.md)
+  - [YAML construction](floorplan_yaml_construction.md)

--- a/python-code/docs/floorplan_extraction.md
+++ b/python-code/docs/floorplan_extraction.md
@@ -1,0 +1,82 @@
+# Floorplan extraction
+
+The floorplan extractor converts labelled DXF room polygons into the YAML wall
+format used by the simulation. Source polygons can follow opposite faces of the
+same physical wall, leaving a wall-thickness gap between adjacent rooms.
+
+Shared-wall normalisation detects plausible pairs of parallel wall faces and
+moves accepted overlaps to a common midline. The example script writes:
+
+- `output.yaml`, containing the resulting room geometry;
+- `output_diagnostic.png`, showing the extraction and shared-wall decisions.
+
+Run the example from `python-code`:
+
+```sh
+uv run python ../examples/floorplan_extraction.py
+```
+
+## Diagnostic classes
+
+The coloured lines in `output_diagnostic.png` explain the outcome of
+shared-wall processing. They are diagnostic overlays; the underlying polygon
+geometry is already normalised before plotting.
+
+### Green: accepted shared wall
+
+A green solid line is an overlap that passed candidate detection and was
+successfully applied to both room polygons. Both final polygon boundaries
+contain the same midline coordinates.
+
+These arise when the wall faces:
+
+- are sufficiently parallel;
+- have a gap within the configured range;
+- have enough overlapping length or aggregate wall coverage;
+- are not blocked by another room;
+- do not conflict with a competing match; and
+- can be applied while keeping both polygons valid.
+
+### Yellow: rejected shared wall
+
+A yellow dashed line is the actual overlap portion of a pair rejected during
+candidate detection. It does not alter either polygon.
+
+Common causes are:
+
+- the overlap is shorter than `min_overlap_length`;
+- the overlap ratio is below `min_overlap_ratio`;
+- the gap is outside the configured range; or
+- another room intersects the strip between the proposed wall faces.
+
+Yellow can appear next to green when different intervals of the same original
+wall segment receive different decisions.
+
+### Purple: rejected because geometry would become invalid
+
+A purple dotted line passed geometric candidate detection, but applying it
+would make at least one room polygon invalid, for example by creating a
+self-intersection. It is therefore excluded from the final geometry.
+
+Candidates are attempted transactionally, longest overlap first. A candidate
+is marked green only when both affected polygons remain valid; otherwise it is
+recorded as `normalisation_invalid_geometry` and shown in purple.
+
+### Red: ambiguous match
+
+If present, a red dashed line indicates competing candidates that overlap on
+the same source wall interval. The extractor cannot safely select one match, so
+none of the competing overlaps are applied.
+
+## Interpreting the image
+
+The diagnostic should be read as follows:
+
+- green confirms a shared boundary in the generated polygons;
+- yellow indicates a threshold or obstruction decision to review;
+- purple identifies a candidate that needs safer polygon-rewriting logic or
+  source-geometry investigation;
+- red identifies a matching ambiguity that requires disambiguation.
+
+Removing the diagnostic overlay does not undo normalisation. It only removes
+the coloured explanation of decisions from the plot.

--- a/python-code/docs/floorplan_extraction.md
+++ b/python-code/docs/floorplan_extraction.md
@@ -1,82 +1,179 @@
 # Floorplan extraction
 
-The floorplan extractor converts labelled DXF room polygons into the YAML wall
-format used by the simulation. Source polygons can follow opposite faces of the
-same physical wall, leaving a wall-thickness gap between adjacent rooms.
+The floorplan extractor converts labelled DXF geometry into the YAML room
+format used by the simulation. It is intended for local Cartesian floorplans;
+no coordinate reference system is required.
 
-Shared-wall normalisation detects plausible pairs of parallel wall faces and
-moves accepted overlaps to a common midline. The example script writes:
+The extraction pipeline:
 
-- `output.yaml`, containing the resulting room geometry;
-- `output_diagnostic.png`, showing the extraction and shared-wall decisions.
+1. reads room boundary linework and polygonises it;
+2. filters and attaches room labels for the configured floor;
+3. applies configured polygon splits, additions, and merges;
+4. normalises accepted adjacent wall faces to a shared midline;
+5. projects CAD door symbols onto subsections of the final room boundaries;
+6. serialises labelled rooms as wall and door line segments.
 
-Run the example from `python-code`:
+The resulting geometry represents walls and doors as zero-thickness lines.
+Physical wall thickness can be applied when the YAML is loaded into another
+model.
+
+## Running the example
+
+Run the example from the `python-code` directory:
 
 ```sh
 uv run python ../examples/floorplan_extraction.py
 ```
 
-## Diagnostic classes
+The default paths are relative to the current directory:
 
-The coloured lines in `output_diagnostic.png` explain the outcome of
-shared-wall processing. They are diagnostic overlays; the underlying polygon
-geometry is already normalised before plotting.
+- `floorplan.dxf`: source floorplan;
+- `config.yaml`: extraction configuration;
+- `output.yaml`: extracted simulation geometry;
+- `output_diagnostic.png`: labelled room and door diagnostic.
 
-### Green: accepted shared wall
+Alternative paths can be supplied explicitly:
 
-A green solid line is an overlap that passed candidate detection and was
-successfully applied to both room polygons. Both final polygon boundaries
-contain the same midline coordinates.
+```sh
+uv run python ../examples/floorplan_extraction.py \
+  --dxf path/to/floorplan.dxf \
+  --config path/to/config.yaml \
+  --output path/to/output.yaml \
+  --diagnostic path/to/output_diagnostic.png
+```
 
-These arise when the wall faces:
+The example writes parent directories for the output files when required.
+Building name, address, and floor level are example constants in the script
+and should be adapted for production use.
 
-- are sufficiently parallel;
-- have a gap within the configured range;
-- have enough overlapping length or aggregate wall coverage;
-- are not blocked by another room;
-- do not conflict with a competing match; and
-- can be applied while keeping both polygons valid.
+## Configuration
 
-### Yellow: rejected shared wall
+The configuration is a YAML mapping. The `polygons` block is required; all
+other blocks are optional.
 
-A yellow dashed line is the actual overlap portion of a pair rejected during
-candidate detection. It does not alter either polygon.
+```yaml
+polygons:
+  polygon_layer_name: "ROOM_BOUNDARIES"
+  label_layer_name: "ROOM_LABELS"
+  polygon_label_column: "Text"
+  polygon_label_target: "room_numbers"
+  floor_filter: "E02"
+  excluded_room_numbers: []
 
-Common causes are:
+doors:
+  layer_name: "Internal doors"
+  entity_col: "EntityHandle"
+  out_col: "doors"
+  predicate: "intersects"
 
-- the overlap is shorter than `min_overlap_length`;
-- the overlap ratio is below `min_overlap_ratio`;
-- the gap is outside the configured range; or
-- another room intersects the strip between the proposed wall faces.
+shared_walls:
+  enabled: true
+  min_gap: 50.0
+  max_gap: 250.0
+  angle_tolerance_degrees: 2.0
+  min_overlap_ratio: 0.5
+  min_overlap_length: 150.0
+  canonical_line: "midline"
+```
 
-Yellow can appear next to green when different intervals of the same original
-wall segment receive different decisions.
+### Room polygons and labels
 
-### Purple: rejected because geometry would become invalid
+`polygon_layer_name` identifies the linework used to construct room polygons.
+`label_layer_name` identifies the room-label geometries. Labels are normalised
+to the line beginning with `floor_filter`, then excluded room numbers are
+removed before spatial attachment.
 
-A purple dotted line passed geometric candidate detection, but applying it
-would make at least one room polygon invalid, for example by creating a
-self-intersection. It is therefore excluded from the final geometry.
+Polygons with no label, ambiguous labels, no attached doors, or unresolved
+shared-wall decisions are marked for review by the returned GeoDataFrame.
 
-Candidates are attempted transactionally, longest overlap first. A candidate
-is marked green only when both affected polygons remain valid; otherwise it is
-recorded as `normalisation_invalid_geometry` and shown in purple.
+### Explicit polygon corrections
 
-### Red: ambiguous match
+Floorplan-specific corrections are applied through three optional lists:
 
-If present, a red dashed line indicates competing candidates that overlap on
-the same source wall interval. The extractor cannot safely select one match, so
-none of the competing overlaps are applied.
+- `polygon_splits` divides a selected polygon with configured cut lines and
+  assigns labels using seed points;
+- `polygon_additions` creates a missing polygon from explicit coordinates;
+- `polygon_merges` combines labelled source polygons into one target polygon.
 
-## Interpreting the image
+Splits and additions occur before label attachment. Merges occur before
+shared-wall and door normalisation.
 
-The diagnostic should be read as follows:
+### Shared walls
 
-- green confirms a shared boundary in the generated polygons;
-- yellow indicates a threshold or obstruction decision to review;
-- purple identifies a candidate that needs safer polygon-rewriting logic or
-  source-geometry investigation;
-- red identifies a matching ambiguity that requires disambiguation.
+Source room polygons often follow opposite faces of the same physical wall.
+Shared-wall normalisation detects plausible parallel overlaps and moves both
+room boundaries to a common midline.
 
-Removing the diagnostic overlay does not undo normalisation. It only removes
-the coloured explanation of decisions from the plot.
+Candidates must satisfy the configured gap, angle, overlap length, and overlap
+ratio thresholds. Candidates are rejected when another room occupies the strip
+between the wall faces, when matches are ambiguous, or when applying the
+midline would invalidate a room polygon.
+
+The result includes:
+
+- `shared_wall_count`;
+- `shared_wall_review`;
+- `shared_wall_rejections`;
+- detailed detection records in
+  `GeoDataFrame.attrs["shared_wall_detection"]`.
+
+### Doors
+
+Door entities in architectural DXF files may contain leaf edges, frames, swing
+arcs, and other symbol geometry. The extractor groups geometry by
+`entity_col`, then projects each door onto a matching final room-boundary
+segment.
+
+The output door is therefore a canonical line:
+
+- it lies on a room wall;
+- its length represents the detected opening along that wall;
+- the same coordinates are attached to both connected rooms where possible;
+- CAD swing and leaf geometry is not written to the simulation YAML.
+
+Attachment diagnostics are stored in
+`GeoDataFrame.attrs["door_attachment_report"]`. A warning is recorded when a
+door cannot be projected onto any room or is attached to more rooms than the
+configured maximum.
+
+## Output YAML
+
+Each room contains a name, ordered wall segments, and door segments:
+
+```yaml
+rooms:
+  - name: E02NN012
+    walls:
+      - [x1, y1, x2, y2]
+    doors:
+      - [x1, y1, x2, y2]
+```
+
+Door coordinates overlay subsections of the corresponding wall boundaries.
+Shared doors are repeated in each connected room because room construction
+uses those coordinates to identify connectivity.
+
+## Diagnostic image
+
+The example plots:
+
+- room polygons in pale blue;
+- final room boundaries in grey;
+- room labels at representative interior points;
+- canonical door openings as solid red overlays on the wall boundaries.
+
+A white underlay makes door segments visible against the room boundary.
+Shared doors are deduplicated for plotting, so each physical opening appears
+once even though it is present in both room records.
+
+The example also contains an optional shared-wall diagnostic helper. When
+enabled, it can display accepted midlines and rejected candidate overlaps.
+This overlay is intended for extraction review rather than production output.
+
+## API reference
+
+The generated API documentation covers:
+
+- [DXF extraction](api/floorplan_dxf_extraction.md);
+- [shared-wall normalisation](api/floorplan_shared_walls.md);
+- [YAML construction](api/floorplan_yaml_construction.md).

--- a/python-code/docs/floorplan_extraction.md
+++ b/python-code/docs/floorplan_extraction.md
@@ -109,6 +109,12 @@ ratio thresholds. Candidates are rejected when another room occupies the strip
 between the wall faces, when matches are ambiguous, or when applying the
 midline would invalidate a room polygon.
 
+Candidate selection uses a Shapely spatial index before the exact geometric
+checks. Accepted candidates and rejection reasons that can require review are
+the supported diagnostic contract. `gap_too_large` records for distant segment
+pairs are broad-phase implementation details and are not guaranteed, because
+those pairs may be excluded before exact evaluation.
+
 The result includes:
 
 - `shared_wall_count`;
@@ -179,10 +185,10 @@ suite using synthetic square-room grids:
 uv run python benchmarks/shared_wall_detection.py
 ```
 
-The script reports room and wall-segment counts, accepted and rejected records,
-and median and best timings for three input sizes. Use `--grid-sizes`,
-`--repeat`, and `--warmup` to control a run. It uses generated local Cartesian
-geometry only; no real or sensitive floorplan data is loaded.
+The script reports room and wall-segment counts, indexed and exhaustive median
+timings, speed-up, and material result counts for three input sizes. Use
+`--grid-sizes`, `--repeat`, and `--warmup` to control a run. It uses generated
+local Cartesian geometry only; no real or sensitive floorplan data is loaded.
 
 The baseline recorded on 20 June 2026 for the exhaustive implementation is:
 
@@ -199,6 +205,21 @@ runs.
 | 12x12 |   144 |      576 |   0.793025 | 0.786961 |      264 |   76,032 |
 
 <!-- shared-wall-baseline-end -->
+
+The indexed implementation was compared with the retained exhaustive reference
+on the same environment and benchmark settings:
+
+|  Grid | Rooms | Segments | Indexed median (s) | Exhaustive median (s) | Speed-up |
+| ----: | ----: | -------: | -----------------: | --------------------: | -------: |
+|   4x4 |    16 |       64 |           0.011804 |              0.011553 |    0.98x |
+|   8x8 |    64 |      256 |           0.048875 |              0.095364 |    1.95x |
+| 12x12 |   144 |      576 |           0.110366 |              0.383982 |    3.48x |
+
+All three comparisons produced the same accepted and material rejection counts.
+The small layout is effectively unchanged, while the benefit increases with
+the number of wall segments. At 12x12, the indexed result is about 7.2 times
+faster than the original task-1 exhaustive baseline of 0.793025 seconds; part
+of that additional gain comes from indexing third-room obstruction queries.
 
 Timings are descriptive rather than test thresholds because they depend on the
 machine and runtime environment. Candidate and rejection counts provide a

--- a/python-code/docs/floorplan_extraction.md
+++ b/python-code/docs/floorplan_extraction.md
@@ -170,6 +170,40 @@ The example also contains an optional shared-wall diagnostic helper. When
 enabled, it can display accepted midlines and rejected candidate overlaps.
 This overlay is intended for extraction review rather than production output.
 
+## Shared-wall performance baseline
+
+Shared-wall candidate detection can be measured independently of the unit-test
+suite using synthetic square-room grids:
+
+```sh
+uv run python benchmarks/shared_wall_detection.py
+```
+
+The script reports room and wall-segment counts, accepted and rejected records,
+and median and best timings for three input sizes. Use `--grid-sizes`,
+`--repeat`, and `--warmup` to control a run. It uses generated local Cartesian
+geometry only; no real or sensitive floorplan data is loaded.
+
+The baseline recorded on 20 June 2026 for the exhaustive implementation is:
+
+<!-- shared-wall-baseline-start -->
+
+Environment: Python 3.13.11, Shapely 2.1.2,
+Linux 7.0.10-1-MANJARO x86-64. Each size used one warm-up and three measured
+runs.
+
+|  Grid | Rooms | Segments | Median (s) | Best (s) | Accepted | Rejected |
+| ----: | ----: | -------: | ---------: | -------: | -------: | -------: |
+|   4x4 |    16 |       64 |   0.013184 | 0.012707 |       24 |      768 |
+|   8x8 |    64 |      256 |   0.162462 | 0.155485 |      112 |   14,336 |
+| 12x12 |   144 |      576 |   0.793025 | 0.786961 |      264 |   76,032 |
+
+<!-- shared-wall-baseline-end -->
+
+Timings are descriptive rather than test thresholds because they depend on the
+machine and runtime environment. Candidate and rejection counts provide a
+deterministic correctness check alongside the regression tests.
+
 ## API reference
 
 The generated API documentation covers:

--- a/python-code/mkdocs.yml
+++ b/python-code/mkdocs.yml
@@ -36,6 +36,7 @@ theme:
 nav:
   - Overview: index.md
   - The Toy Problem: toy_problem.md
+  - Floorplan extraction: floorplan_extraction.md
   - API reference:
       - Overview: api/index.md
       - Agent: api/agent.md

--- a/python-code/mkdocs.yml
+++ b/python-code/mkdocs.yml
@@ -54,6 +54,10 @@ nav:
       - Simulation: api/simulation.md
       - Simulation Factory: api/simulation_factory.md
       - Task: api/task.md
+      - Floorplan extraction:
+          - DXF extraction: api/floorplan_dxf_extraction.md
+          - Shared walls: api/floorplan_shared_walls.md
+          - YAML construction: api/floorplan_yaml_construction.md
 
 plugins:
   - search

--- a/python-code/src/floorplan_extractor/README.md
+++ b/python-code/src/floorplan_extractor/README.md
@@ -1,0 +1,21 @@
+# Floorplan extractor
+
+The `floorplan_extractor` package converts labelled DXF floorplans into the
+room, wall, and door geometry consumed by the AMR Hub simulation.
+
+The package is split into three modules:
+
+- `dxf_polygon_extraction` reads configured DXF layers, constructs and labels
+  room polygons, applies explicit geometry corrections, and attaches doors;
+- `shared_walls` replaces accepted pairs of wall faces with a common midline;
+- `yaml_construction` serialises the resulting room geometry to the simulation
+  YAML schema.
+
+Walls and doors use a centreline representation. Shared walls are normalised to
+one common line, while doors are projected onto subsections of the final room
+boundaries. Physical wall thickness can therefore be applied by downstream
+consumers without preserving CAD wall-face or door-symbol thickness.
+
+See the
+[floorplan extraction guide](../../docs/floorplan_extraction.md)
+for configuration, commands, diagnostics, and output details.

--- a/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
+++ b/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
@@ -386,6 +386,7 @@ def attach_room_doors(
         msg = "labelled_polygons must have a 'geometry' column"
         raise KeyError(msg)
 
+    source_attrs = dict(labelled_polygons.attrs)
     combined_doors = _combine_door_geometries(doors, config)
 
     rooms = labelled_polygons.copy()
@@ -451,6 +452,7 @@ def attach_room_doors(
 
     result["door_count"] = result[config.out_col].apply(len)
 
+    result.attrs.update(source_attrs)
     result.attrs["door_attachment_report"] = unresolved_doors.to_dict(orient="records")
 
     return result

--- a/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
+++ b/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
@@ -43,6 +43,7 @@ from shapely.ops import linemerge, polygonize, unary_union
 XY = tuple[float, float]
 DoorQuad = list[float]  # [x1, y1, x2, y2]
 MIN_DOOR_ENDPOINTS: int = 2
+VALID_SHARED_WALL_CANONICAL_LINES: frozenset[str] = frozenset({"midline"})
 
 
 @dataclass(frozen=True)
@@ -106,6 +107,39 @@ class DoorAttachmentConfig:
 
 
 @dataclass(frozen=True)
+class SharedWallConfig:
+    """
+    Configuration for optional shared-wall normalisation.
+
+    Attributes
+    ----------
+    enabled : bool
+        Whether shared-wall normalisation should run.
+    min_gap : float
+        Minimum distance between paired wall faces.
+    max_gap : float
+        Maximum distance between paired wall faces.
+    angle_tolerance_degrees : float
+        Maximum angle difference for wall faces to be considered parallel.
+    min_overlap_ratio : float
+        Minimum projected overlap ratio required for pairing.
+    min_overlap_length : float
+        Minimum projected overlap length required for pairing.
+    canonical_line : str
+        Strategy for choosing the replacement shared wall line.
+
+    """
+
+    enabled: bool = False
+    min_gap: float = 50.0
+    max_gap: float = 130.0
+    angle_tolerance_degrees: float = 2.0
+    min_overlap_ratio: float = 0.75
+    min_overlap_length: float = 250.0
+    canonical_line: str = "midline"
+
+
+@dataclass(frozen=True)
 class ExtractionConfig:
     """
     Top-level configuration for DXF extraction.
@@ -118,12 +152,16 @@ class ExtractionConfig:
         Name of the DXF layer containing door geometries.
     doors : DoorAttachmentConfig or None
         If provided, doors are extracted and attached to polygons.
+    shared_walls : SharedWallConfig or None
+        If provided and enabled, shared-wall normalisation may be applied by
+        downstream processing.
 
     """
 
     polygons: PolygonExtractionConfig
     door_layer_name: str | None = None
     doors: DoorAttachmentConfig | None = None
+    shared_walls: SharedWallConfig | None = None
 
 
 def config_from_yaml(path: Path) -> ExtractionConfig:
@@ -148,6 +186,15 @@ def config_from_yaml(path: Path) -> ExtractionConfig:
       y_col: y
       out_col: doors
       predicate: intersects
+
+    shared_walls:                # optional
+      enabled: true
+      min_gap: 50
+      max_gap: 130
+      angle_tolerance_degrees: 2
+      min_overlap_ratio: 0.75
+      min_overlap_length: 250
+      canonical_line: midline
 
     Parameters
     ----------
@@ -182,6 +229,7 @@ def config_from_yaml(path: Path) -> ExtractionConfig:
 
     door_layer_name: str | None = None
     door_config: DoorAttachmentConfig | None = None
+    shared_wall_config: SharedWallConfig | None = None
 
     if "doors" in data:
         door_block = data["doors"]
@@ -204,10 +252,41 @@ def config_from_yaml(path: Path) -> ExtractionConfig:
             predicate=door_block.get("predicate", "intersects"),
         )
 
+    if "shared_walls" in data:
+        shared_wall_block = data["shared_walls"]
+
+        if not isinstance(shared_wall_block, dict):
+            msg = "'shared_walls' block must be a mapping"
+            raise TypeError(msg)
+
+        canonical_line = str(shared_wall_block.get("canonical_line", "midline"))
+        if canonical_line not in VALID_SHARED_WALL_CANONICAL_LINES:
+            valid_values = ", ".join(sorted(VALID_SHARED_WALL_CANONICAL_LINES))
+            msg = (
+                "'shared_walls.canonical_line' must be one of "
+                f"{valid_values}; got {canonical_line!r}"
+            )
+            raise ValueError(msg)
+
+        shared_wall_config = SharedWallConfig(
+            enabled=bool(shared_wall_block.get("enabled", False)),
+            min_gap=float(shared_wall_block.get("min_gap", 50.0)),
+            max_gap=float(shared_wall_block.get("max_gap", 130.0)),
+            angle_tolerance_degrees=float(
+                shared_wall_block.get("angle_tolerance_degrees", 2.0)
+            ),
+            min_overlap_ratio=float(shared_wall_block.get("min_overlap_ratio", 0.75)),
+            min_overlap_length=float(
+                shared_wall_block.get("min_overlap_length", 250.0)
+            ),
+            canonical_line=canonical_line,
+        )
+
     return ExtractionConfig(
         polygons=polygons_cfg,
         door_layer_name=door_layer_name,
         doors=door_config,
+        shared_walls=shared_wall_config,
     )
 
 

--- a/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
+++ b/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
@@ -435,8 +435,24 @@ def _flatten_z_points(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     return g
 
 
+def _repair_polygon_geometry(geom: BaseGeometry) -> BaseGeometry:
+    geom = shapely.force_2d(geom)
+
+    if geom.is_empty:
+        return geom
+
+    if not geom.is_valid:
+        geom = shapely.make_valid(geom)
+
+    if geom.geom_type == "MultiPolygon":
+        return max(geom.geoms, key=lambda g: g.area)
+
+    return geom
+
+
 def _generate_polygons(
-    gdf: gpd.GeoDataFrame, polygon_layer_name: str
+    gdf: gpd.GeoDataFrame,
+    polygon_layer_name: str,
 ) -> gpd.GeoDataFrame:
     """
     Generate polygon geometries from linework in a specified DXF layer.
@@ -458,8 +474,28 @@ def _generate_polygons(
         specified layer.
 
     """
-    polygon_layer = gdf.loc[gdf["Layer"] == polygon_layer_name, :]
-    return gpd.GeoDataFrame(geometry=list(polygonize(polygon_layer.geometry)))
+    polygon_layer = gdf.loc[gdf["Layer"] == polygon_layer_name, ["geometry"]].copy()
+    polygon_layer["geometry"] = shapely.force_2d(polygon_layer.geometry)
+
+    polygon_layer = polygon_layer.loc[
+        polygon_layer.geometry.geom_type.isin(
+            {"LineString", "MultiLineString", "LinearRing"}
+        ),
+        :,
+    ]
+
+    raw_polygons = list(polygonize(polygon_layer.geometry))
+    repaired = [_repair_polygon_geometry(geom) for geom in raw_polygons]
+
+    polygons = gpd.GeoDataFrame(geometry=repaired, crs=gdf.crs)
+    polygons = polygons.loc[
+        polygons.geometry.geom_type == "Polygon",
+        :,
+    ]
+    polygons = polygons.loc[~polygons.geometry.is_empty, :]
+    polygons = polygons.loc[polygons.geometry.area > 0, :]
+
+    return polygons.reset_index(drop=True)
 
 
 def _generate_room_numbers(

--- a/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
+++ b/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
@@ -29,6 +29,7 @@ internal helpers and are not part of the public API.
 """
 
 from dataclasses import dataclass, field
+from itertools import pairwise
 from pathlib import Path
 from typing import Any
 
@@ -535,19 +536,130 @@ def _combine_door_geometries(
         if geom.length < config.min_door_length:
             continue
 
-        door_quad = _line_to_xyxy(geom)
+        rows.append(
+            {
+                config.entity_col: entity_id,
+                "geometry": geom,
+            }
+        )
+
+    return gpd.GeoDataFrame(rows, geometry="geometry", crs=doors.crs)
+
+
+def _polygon_boundary_segments(geometry: BaseGeometry) -> list[LineString]:
+    if not isinstance(geometry, Polygon) or geometry.is_empty:
+        return []
+
+    coords = list(geometry.exterior.coords)
+    return [LineString([start, end]) for start, end in pairwise(coords) if start != end]
+
+
+def _project_geometry_onto_segment(
+    geometry: BaseGeometry,
+    segment: LineString,
+    tolerance: float,
+    min_length: float,
+) -> LineString | None:
+    nearby_geometry = geometry.intersection(
+        segment.buffer(tolerance, cap_style="square")
+    )
+    if nearby_geometry.is_empty:
+        return None
+
+    coordinates = shapely.get_coordinates(nearby_geometry)
+    if len(coordinates) < MIN_DOOR_ENDPOINTS:
+        return None
+
+    projected_distances = [
+        segment.project(Point(float(x), float(y))) for x, y in coordinates
+    ]
+    start_distance = min(projected_distances)
+    end_distance = max(projected_distances)
+    if end_distance - start_distance < min_length:
+        return None
+
+    start = segment.interpolate(start_distance)
+    end = segment.interpolate(end_distance)
+    return LineString([start, end])
+
+
+def _canonical_line_key(line: LineString) -> tuple[XY, XY]:
+    start = (round(line.coords[0][0], 8), round(line.coords[0][1], 8))
+    end = (round(line.coords[-1][0], 8), round(line.coords[-1][1], 8))
+    ordered = sorted((start, end))
+    return ordered[0], ordered[1]
+
+
+def _project_doors_onto_room_boundaries(
+    doors: gpd.GeoDataFrame,
+    rooms: gpd.GeoDataFrame,
+    config: DoorAttachmentConfig,
+) -> gpd.GeoDataFrame:
+    rows = []
+
+    room_segments = [
+        (room_id, segment)
+        for room_id, geometry in rooms.geometry.items()
+        for segment in _polygon_boundary_segments(geometry)
+    ]
+
+    for _, door in doors.iterrows():
+        candidates: dict[
+            tuple[XY, XY],
+            tuple[LineString, set[int]],
+        ] = {}
+
+        for room_id, segment in room_segments:
+            projection = _project_geometry_onto_segment(
+                door.geometry,
+                segment,
+                config.boundary_tolerance,
+                config.min_door_length,
+            )
+            if projection is None:
+                continue
+
+            key = _canonical_line_key(projection)
+            if key not in candidates:
+                candidates[key] = (projection, set())
+            candidates[key][1].add(int(room_id))
+
+        if not candidates:
+            continue
+
+        projection, room_ids = max(
+            candidates.values(),
+            key=lambda candidate: (
+                len(candidate[1]),
+                candidate[0].length,
+            ),
+        )
+        door_quad = _line_to_xyxy(projection)
         if door_quad is None:
             continue
 
         rows.append(
             {
-                config.entity_col: entity_id,
-                "geometry": geom,
+                config.entity_col: door[config.entity_col],
+                "geometry": projection,
                 "door_xyxy": door_quad,
+                "projected_room_ids": room_ids,
             }
         )
 
-    return gpd.GeoDataFrame(rows, geometry="geometry", crs=doors.crs)
+    if not rows:
+        return gpd.GeoDataFrame(
+            columns=[
+                config.entity_col,
+                "door_xyxy",
+                "projected_room_ids",
+                "geometry",
+            ],
+            geometry="geometry",
+            crs=rooms.crs,
+        )
+
+    return gpd.GeoDataFrame(rows, geometry="geometry", crs=rooms.crs)
 
 
 def attach_room_doors(
@@ -564,8 +676,7 @@ def attach_room_doors(
         GeoDataFrame containing room polygon geometries. The index is used as
         the room identifier.
     doors : geopandas.GeoDataFrame
-        GeoDataFrame containing door geometries, with two rows per physical
-        door.
+        GeoDataFrame containing one or more CAD geometries per physical door.
     config : DoorAttachmentConfig, default DoorAttachmentConfig()
         Configuration controlling the join predicate, column names, and output
         column name.
@@ -598,46 +709,42 @@ def attach_room_doors(
 
     source_attrs = dict(labelled_polygons.attrs)
     combined_doors = _combine_door_geometries(doors, config)
-
-    rooms = labelled_polygons.copy()
-    rooms["_room_idx"] = rooms.index
-    rooms["_boundary_geometry"] = rooms.geometry.boundary.buffer(
-        config.boundary_tolerance
+    projected_doors = _project_doors_onto_room_boundaries(
+        combined_doors,
+        labelled_polygons,
+        config,
     )
 
-    boundary_gdf = gpd.GeoDataFrame(
-        rooms[["_room_idx"]],
-        geometry=rooms["_boundary_geometry"],
-        crs=rooms.crs,
-    )
+    valid_rows = [
+        {
+            "_room_idx": room_id,
+            config.entity_col: door[config.entity_col],
+            "door_xyxy": door["door_xyxy"],
+        }
+        for _, door in projected_doors.iterrows()
+        for room_id in door["projected_room_ids"]
+    ]
+    valid = pd.DataFrame(valid_rows)
 
-    joined = gpd.sjoin(
-        combined_doors[[config.entity_col, "door_xyxy", "geometry"]],
-        boundary_gdf,
-        how="left",
-        predicate="intersects",
-    )
-
-    valid = joined.dropna(subset=["_room_idx"]).copy()
-    valid["_room_idx"] = valid["_room_idx"].astype(int)
-
-    attachments = (
-        valid.groupby(["_room_idx", config.entity_col], sort=False)["door_xyxy"]
-        .first()
-        .reset_index()
-    )
-
-    doors_by_room = (
-        attachments.groupby("_room_idx", sort=False)["door_xyxy"]
-        .apply(list)
-        .rename(config.out_col)
-    )
-
-    attachment_counts = (
-        valid.groupby(config.entity_col)["_room_idx"]
-        .nunique()
-        .rename("attached_room_count")
-    )
+    if valid.empty:
+        doors_by_room = pd.Series(name=config.out_col, dtype=object)
+        attachment_counts = pd.Series(name="attached_room_count", dtype=int)
+    else:
+        attachments = (
+            valid.groupby(["_room_idx", config.entity_col], sort=False)["door_xyxy"]
+            .first()
+            .reset_index()
+        )
+        doors_by_room = (
+            attachments.groupby("_room_idx", sort=False)["door_xyxy"]
+            .apply(list)
+            .rename(config.out_col)
+        )
+        attachment_counts = (
+            valid.groupby(config.entity_col)["_room_idx"]
+            .nunique()
+            .rename("attached_room_count")
+        )
 
     unresolved_doors = (
         combined_doors[[config.entity_col]]

--- a/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
+++ b/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
@@ -141,6 +141,14 @@ class PolygonAdditionConfig:
 
 
 @dataclass(frozen=True)
+class PolygonMergeConfig:
+    """Configuration for merging labelled polygons into one target polygon."""
+
+    target_label: str
+    source_labels: list[str]
+
+
+@dataclass(frozen=True)
 class ExtractionConfig:
     """
     Top-level configuration for DXF extraction.
@@ -160,6 +168,8 @@ class ExtractionConfig:
         Floorplan-specific polygon splits applied before label attachment.
     polygon_additions : list[PolygonAdditionConfig]
         Floorplan-specific polygons added before label attachment.
+    polygon_merges : list[PolygonMergeConfig]
+        Floorplan-specific labelled polygons merged before geometry normalisation.
 
     """
 
@@ -169,6 +179,7 @@ class ExtractionConfig:
     shared_walls: SharedWallConfig | None = None
     polygon_splits: list[PolygonSplitConfig] = field(default_factory=list)
     polygon_additions: list[PolygonAdditionConfig] = field(default_factory=list)
+    polygon_merges: list[PolygonMergeConfig] = field(default_factory=list)
 
 
 def config_from_yaml(path: Path) -> ExtractionConfig:
@@ -216,6 +227,10 @@ def config_from_yaml(path: Path) -> ExtractionConfig:
         coordinates:
           - [x, y]
 
+    polygon_merges:              # optional
+      - target_label: ROOM_CODE
+        source_labels: [CORRIDOR]
+
     Parameters
     ----------
     path : pathlib.Path
@@ -250,8 +265,6 @@ def config_from_yaml(path: Path) -> ExtractionConfig:
     door_layer_name: str | None = None
     door_config: DoorAttachmentConfig | None = None
     shared_wall_config: SharedWallConfig | None = None
-    polygon_splits: list[PolygonSplitConfig] = []
-    polygon_additions: list[PolygonAdditionConfig] = []
 
     if "doors" in data:
         door_block = data["doors"]
@@ -304,22 +317,7 @@ def config_from_yaml(path: Path) -> ExtractionConfig:
             canonical_line=canonical_line,
         )
 
-    if "polygon_splits" in data:
-        split_blocks = data["polygon_splits"]
-        if not isinstance(split_blocks, list):
-            msg = "'polygon_splits' block must be a list"
-            raise TypeError(msg)
-
-        polygon_splits = [_parse_polygon_split(block) for block in split_blocks]
-
-    if "polygon_additions" in data:
-        addition_blocks = data["polygon_additions"]
-        if not isinstance(addition_blocks, list):
-            msg = "'polygon_additions' block must be a list"
-            raise TypeError(msg)
-        polygon_additions = [
-            _parse_polygon_addition(block) for block in addition_blocks
-        ]
+    polygon_splits, polygon_additions, polygon_merges = _parse_polygon_corrections(data)
 
     return ExtractionConfig(
         polygons=polygons_cfg,
@@ -328,6 +326,37 @@ def config_from_yaml(path: Path) -> ExtractionConfig:
         shared_walls=shared_wall_config,
         polygon_splits=polygon_splits,
         polygon_additions=polygon_additions,
+        polygon_merges=polygon_merges,
+    )
+
+
+def _parse_polygon_corrections(
+    data: dict[str, Any],
+) -> tuple[
+    list[PolygonSplitConfig],
+    list[PolygonAdditionConfig],
+    list[PolygonMergeConfig],
+]:
+    """Parse optional floorplan-specific polygon correction blocks."""
+    split_blocks = data.get("polygon_splits", [])
+    if not isinstance(split_blocks, list):
+        msg = "'polygon_splits' block must be a list"
+        raise TypeError(msg)
+
+    addition_blocks = data.get("polygon_additions", [])
+    if not isinstance(addition_blocks, list):
+        msg = "'polygon_additions' block must be a list"
+        raise TypeError(msg)
+
+    merge_blocks = data.get("polygon_merges", [])
+    if not isinstance(merge_blocks, list):
+        msg = "'polygon_merges' block must be a list"
+        raise TypeError(msg)
+
+    return (
+        [_parse_polygon_split(block) for block in split_blocks],
+        [_parse_polygon_addition(block) for block in addition_blocks],
+        [_parse_polygon_merge(block) for block in merge_blocks],
     )
 
 
@@ -405,6 +434,38 @@ def _parse_polygon_addition(block: object) -> PolygonAdditionConfig:
         coordinates=[
             _parse_xy(coordinate, "coordinates") for coordinate in raw_coordinates
         ],
+    )
+
+
+def _parse_polygon_merge(block: object) -> PolygonMergeConfig:
+    """Parse one configured merge of labelled polygons."""
+    if not isinstance(block, dict):
+        msg = "Each 'polygon_merges' entry must be a mapping"
+        raise TypeError(msg)
+
+    target_label = block.get("target_label")
+    if not isinstance(target_label, str) or not target_label.strip():
+        msg = "Polygon merge 'target_label' must be a non-empty string"
+        raise ValueError(msg)
+
+    source_labels = block.get("source_labels")
+    if (
+        not isinstance(source_labels, list)
+        or not source_labels
+        or not all(isinstance(label, str) and label.strip() for label in source_labels)
+    ):
+        msg = "Polygon merge 'source_labels' must be a non-empty list of strings"
+        raise ValueError(msg)
+
+    clean_target = target_label.strip()
+    clean_sources = [label.strip() for label in source_labels]
+    if clean_target in clean_sources:
+        msg = "Polygon merge target cannot also be a source label"
+        raise ValueError(msg)
+
+    return PolygonMergeConfig(
+        target_label=clean_target,
+        source_labels=clean_sources,
     )
 
 
@@ -833,6 +894,67 @@ def _apply_addition_labels(
     return result
 
 
+def _apply_polygon_merges(
+    polygons: gpd.GeoDataFrame,
+    merge_configs: list[PolygonMergeConfig],
+    polygon_label_target: str,
+) -> gpd.GeoDataFrame:
+    """Merge configured source polygons into a single labelled target polygon."""
+    result = polygons.copy()
+
+    for merge_config in merge_configs:
+        target_indices = result.index[
+            result[polygon_label_target] == merge_config.target_label
+        ]
+        if len(target_indices) != 1:
+            msg = (
+                "Polygon merge target must identify exactly one polygon; "
+                f"label {merge_config.target_label!r} found {len(target_indices)}"
+            )
+            raise ValueError(msg)
+
+        source_indices: list[int] = []
+        for source_label in merge_config.source_labels:
+            matching_indices = result.index[
+                result[polygon_label_target] == source_label
+            ].to_list()
+            if not matching_indices:
+                msg = (
+                    "Polygon merge source must identify at least one polygon; "
+                    f"label {source_label!r} found 0"
+                )
+                raise ValueError(msg)
+            source_indices.extend(matching_indices)
+
+        target_index = target_indices[0]
+        merged_geometry = unary_union(
+            result.loc[[target_index, *source_indices], "geometry"].to_list()
+        )
+        if (
+            not isinstance(merged_geometry, Polygon)
+            or merged_geometry.is_empty
+            or not merged_geometry.is_valid
+        ):
+            msg = (
+                "Polygon merge must produce one valid Polygon; "
+                f"got {merged_geometry.geom_type}"
+            )
+            raise ValueError(msg)
+
+        result.loc[target_index, "geometry"] = merged_geometry
+        result.loc[
+            target_index,
+            [polygon_label_target, "label_count", "label_ambiguous"],
+        ] = [merge_config.target_label, 1, False]
+        result.loc[[target_index], "label_candidates"] = pd.Series(
+            [[merge_config.target_label]],
+            index=[target_index],
+        )
+        result = result.drop(index=source_indices)
+
+    return result.reset_index(drop=True)
+
+
 def _generate_room_numbers(
     gdf: gpd.GeoDataFrame,
     label_layer_name: str,
@@ -1126,6 +1248,11 @@ def extract_polygons(
     labelled_polygons = _apply_addition_labels(
         labelled_polygons,
         config.polygon_additions,
+        config.polygons.polygon_label_target,
+    )
+    labelled_polygons = _apply_polygon_merges(
+        labelled_polygons,
+        config.polygon_merges,
         config.polygons.polygon_label_target,
     )
 

--- a/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
+++ b/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
@@ -100,6 +100,9 @@ class DoorAttachmentConfig:
     y_col: str = "y"
     out_col: str = "doors"
     predicate: str = "intersects"
+    boundary_tolerance: float = 0.1
+    min_door_length: float = 0.2
+    max_attached_rooms: int = 2
 
 
 @dataclass(frozen=True)
@@ -475,6 +478,31 @@ def _attach_centroid_coords(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     return g
 
 
+def _normalise_label(value: str) -> str:
+    return str(value).strip()
+
+
+def _score_label(label: str) -> tuple[int, int, str]:
+    clean = _normalise_label(label)
+    if clean.lower() in {"corridor", "lobby", "stair", "stairs"}:
+        return (1, len(clean), clean)
+
+    has_digit = any(char.isdigit() for char in clean)
+    if has_digit:
+        return (0, len(clean), clean)
+
+    return (2, len(clean), clean)
+
+
+def _choose_primary_label(labels: pd.Series) -> str | None:
+    values = sorted({_normalise_label(v) for v in labels if pd.notna(v)})
+
+    if not values:
+        return None
+
+    return sorted(values, key=_score_label)[0]
+
+
 def _attach_polygon_labels(
     polygons: gpd.GeoDataFrame,
     room_labels: gpd.GeoDataFrame,
@@ -506,19 +534,40 @@ def _attach_polygon_labels(
         and a geometry type indicator column.
 
     """
-    number_polygon_matches = gpd.sjoin(
-        room_labels, polygons, how="left", predicate="within"
+    matches = gpd.sjoin(
+        room_labels,
+        polygons,
+        how="left",
+        predicate="within",
+    ).rename(columns={"index_right": "room_idx"})
+
+    grouped = matches.dropna(subset=["room_idx"]).copy()
+    grouped["room_idx"] = grouped["room_idx"].astype(int)
+
+    label_summary = grouped.groupby("room_idx")[polygon_label_column].agg(
+        primary_label=_choose_primary_label,
+        label_candidates=lambda x: sorted(
+            {_normalise_label(v) for v in x if pd.notna(v)}
+        ),
+        label_count=lambda x: len({_normalise_label(v) for v in x if pd.notna(v)}),
     )
 
-    aggregated_labels = number_polygon_matches.groupby("index_right")[
-        polygon_label_column
-    ].apply(lambda x: ", ".join(sorted(set(x))))
-
-    labelled_polygons = polygons.join(aggregated_labels)
-    labelled_polygons = labelled_polygons.rename(
-        columns={polygon_label_column: polygon_label_target}
+    label_summary = label_summary.rename(
+        columns={"primary_label": polygon_label_target}
     )
+    label_summary["label_ambiguous"] = label_summary["label_count"] > 1
+
+    labelled_polygons = polygons.join(label_summary, how="left")
     labelled_polygons["geometry_type"] = "POLYGON"
+    labelled_polygons["label_candidates"] = labelled_polygons["label_candidates"].apply(
+        lambda v: v if isinstance(v, list) else []
+    )
+    labelled_polygons["label_count"] = (
+        labelled_polygons["label_count"].fillna(0).astype(int)
+    )
+    labelled_polygons["label_ambiguous"] = labelled_polygons["label_ambiguous"].fillna(
+        value=False
+    )
 
     return labelled_polygons
 

--- a/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
+++ b/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
@@ -40,6 +40,8 @@ from shapely.geometry import GeometryCollection, LineString, MultiLineString
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import linemerge, polygonize, unary_union
 
+from floorplan_extractor.shared_walls import SharedWallConfig, normalise_shared_walls
+
 XY = tuple[float, float]
 DoorQuad = list[float]  # [x1, y1, x2, y2]
 MIN_DOOR_ENDPOINTS: int = 2
@@ -104,39 +106,6 @@ class DoorAttachmentConfig:
     boundary_tolerance: float = 0.1
     min_door_length: float = 0.2
     max_attached_rooms: int = 2
-
-
-@dataclass(frozen=True)
-class SharedWallConfig:
-    """
-    Configuration for optional shared-wall normalisation.
-
-    Attributes
-    ----------
-    enabled : bool
-        Whether shared-wall normalisation should run.
-    min_gap : float
-        Minimum distance between paired wall faces.
-    max_gap : float
-        Maximum distance between paired wall faces.
-    angle_tolerance_degrees : float
-        Maximum angle difference for wall faces to be considered parallel.
-    min_overlap_ratio : float
-        Minimum projected overlap ratio required for pairing.
-    min_overlap_length : float
-        Minimum projected overlap length required for pairing.
-    canonical_line : str
-        Strategy for choosing the replacement shared wall line.
-
-    """
-
-    enabled: bool = False
-    min_gap: float = 50.0
-    max_gap: float = 130.0
-    angle_tolerance_degrees: float = 2.0
-    min_overlap_ratio: float = 0.75
-    min_overlap_length: float = 250.0
-    canonical_line: str = "midline"
 
 
 @dataclass(frozen=True)
@@ -841,6 +810,12 @@ def extract_polygons(
         config.polygons.polygon_label_target,
     )
 
+    if config.shared_walls and config.shared_walls.enabled:
+        labelled_polygons = normalise_shared_walls(
+            labelled_polygons,
+            config.shared_walls,
+        )
+
     if config.door_layer_name and config.doors:
         doors = _generate_doors(gdf, config.door_layer_name)
         labelled_polygons = attach_room_doors(
@@ -857,6 +832,7 @@ def extract_polygons(
         ~labelled_polygons["has_label"]
         | labelled_polygons.get("label_ambiguous", False)
         | (labelled_polygons.get("door_count", 0) == 0)
+        | labelled_polygons.get("shared_wall_review", False)
     )
 
     return labelled_polygons

--- a/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
+++ b/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
@@ -28,7 +28,7 @@ The public entry point is `extract_polygons`. All other functions are
 internal helpers and are not part of the public API.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -36,14 +36,21 @@ import geopandas as gpd
 import pandas as pd
 import shapely
 import yaml
-from shapely.geometry import GeometryCollection, LineString, MultiLineString
+from shapely.geometry import (
+    GeometryCollection,
+    LineString,
+    MultiLineString,
+    Point,
+    Polygon,
+)
 from shapely.geometry.base import BaseGeometry
-from shapely.ops import linemerge, polygonize, unary_union
+from shapely.ops import linemerge, polygonize, split, unary_union
 
 from floorplan_extractor.shared_walls import SharedWallConfig, normalise_shared_walls
 
 XY = tuple[float, float]
 DoorQuad = list[float]  # [x1, y1, x2, y2]
+CutLine = tuple[float, float, float, float]
 MIN_DOOR_ENDPOINTS: int = 2
 VALID_SHARED_WALL_CANONICAL_LINES: frozenset[str] = frozenset({"midline"})
 
@@ -109,6 +116,31 @@ class DoorAttachmentConfig:
 
 
 @dataclass(frozen=True)
+class PolygonSplitRegionConfig:
+    """Explicit label for one region produced by a configured polygon split."""
+
+    label: str
+    seed_point: XY
+
+
+@dataclass(frozen=True)
+class PolygonSplitConfig:
+    """Configuration for splitting one polygon at known floorplan boundaries."""
+
+    selector_point: XY
+    cut_lines: list[CutLine]
+    regions: list[PolygonSplitRegionConfig]
+
+
+@dataclass(frozen=True)
+class PolygonAdditionConfig:
+    """Explicit polygon missing from source room-area linework."""
+
+    label: str
+    coordinates: list[XY]
+
+
+@dataclass(frozen=True)
 class ExtractionConfig:
     """
     Top-level configuration for DXF extraction.
@@ -124,6 +156,10 @@ class ExtractionConfig:
     shared_walls : SharedWallConfig or None
         If provided and enabled, shared-wall normalisation may be applied by
         downstream processing.
+    polygon_splits : list[PolygonSplitConfig]
+        Floorplan-specific polygon splits applied before label attachment.
+    polygon_additions : list[PolygonAdditionConfig]
+        Floorplan-specific polygons added before label attachment.
 
     """
 
@@ -131,6 +167,8 @@ class ExtractionConfig:
     door_layer_name: str | None = None
     doors: DoorAttachmentConfig | None = None
     shared_walls: SharedWallConfig | None = None
+    polygon_splits: list[PolygonSplitConfig] = field(default_factory=list)
+    polygon_additions: list[PolygonAdditionConfig] = field(default_factory=list)
 
 
 def config_from_yaml(path: Path) -> ExtractionConfig:
@@ -164,6 +202,19 @@ def config_from_yaml(path: Path) -> ExtractionConfig:
       min_overlap_ratio: 0.75
       min_overlap_length: 250
       canonical_line: midline
+
+    polygon_splits:              # optional
+      - selector_point: [x, y]
+        cut_lines:
+          - [x1, y1, x2, y2]
+        regions:
+          - label: ROOM_CODE
+            seed_point: [x, y]
+
+    polygon_additions:           # optional
+      - label: CORRIDOR
+        coordinates:
+          - [x, y]
 
     Parameters
     ----------
@@ -199,6 +250,8 @@ def config_from_yaml(path: Path) -> ExtractionConfig:
     door_layer_name: str | None = None
     door_config: DoorAttachmentConfig | None = None
     shared_wall_config: SharedWallConfig | None = None
+    polygon_splits: list[PolygonSplitConfig] = []
+    polygon_additions: list[PolygonAdditionConfig] = []
 
     if "doors" in data:
         door_block = data["doors"]
@@ -251,11 +304,107 @@ def config_from_yaml(path: Path) -> ExtractionConfig:
             canonical_line=canonical_line,
         )
 
+    if "polygon_splits" in data:
+        split_blocks = data["polygon_splits"]
+        if not isinstance(split_blocks, list):
+            msg = "'polygon_splits' block must be a list"
+            raise TypeError(msg)
+
+        polygon_splits = [_parse_polygon_split(block) for block in split_blocks]
+
+    if "polygon_additions" in data:
+        addition_blocks = data["polygon_additions"]
+        if not isinstance(addition_blocks, list):
+            msg = "'polygon_additions' block must be a list"
+            raise TypeError(msg)
+        polygon_additions = [
+            _parse_polygon_addition(block) for block in addition_blocks
+        ]
+
     return ExtractionConfig(
         polygons=polygons_cfg,
         door_layer_name=door_layer_name,
         doors=door_config,
         shared_walls=shared_wall_config,
+        polygon_splits=polygon_splits,
+        polygon_additions=polygon_additions,
+    )
+
+
+def _parse_xy(value: object, field_name: str) -> XY:
+    """Parse one configured two-dimensional point."""
+    if not isinstance(value, list) or len(value) != 2:
+        msg = f"'{field_name}' must contain exactly two coordinates"
+        raise ValueError(msg)
+
+    return (float(value[0]), float(value[1]))
+
+
+def _parse_polygon_split(block: object) -> PolygonSplitConfig:
+    """Parse one configured polygon split."""
+    if not isinstance(block, dict):
+        msg = "Each 'polygon_splits' entry must be a mapping"
+        raise TypeError(msg)
+
+    selector_point = _parse_xy(block.get("selector_point"), "selector_point")
+
+    raw_cut_lines = block.get("cut_lines")
+    if not isinstance(raw_cut_lines, list) or not raw_cut_lines:
+        msg = "'cut_lines' must be a non-empty list"
+        raise ValueError(msg)
+    cut_lines: list[CutLine] = []
+    for line in raw_cut_lines:
+        if not isinstance(line, list) or len(line) != 4:
+            msg = "Each 'cut_lines' entry must contain exactly four coordinates"
+            raise ValueError(msg)
+        cut_lines.append(
+            (
+                float(line[0]),
+                float(line[1]),
+                float(line[2]),
+                float(line[3]),
+            )
+        )
+
+    raw_regions = block.get("regions")
+    if not isinstance(raw_regions, list) or not raw_regions:
+        msg = "'regions' must be a non-empty list"
+        raise ValueError(msg)
+    regions: list[PolygonSplitRegionConfig] = []
+    for region in raw_regions:
+        if not isinstance(region, dict) or "label" not in region:
+            msg = "Each split region requires 'label' and 'seed_point'"
+            raise ValueError(msg)
+        regions.append(
+            PolygonSplitRegionConfig(
+                label=str(region["label"]),
+                seed_point=_parse_xy(region.get("seed_point"), "seed_point"),
+            )
+        )
+
+    return PolygonSplitConfig(
+        selector_point=selector_point,
+        cut_lines=cut_lines,
+        regions=regions,
+    )
+
+
+def _parse_polygon_addition(block: object) -> PolygonAdditionConfig:
+    """Parse one explicitly configured polygon."""
+    if not isinstance(block, dict) or "label" not in block:
+        msg = "Each polygon addition requires 'label' and 'coordinates'"
+        raise ValueError(msg)
+
+    raw_coordinates = block.get("coordinates")
+    if not isinstance(raw_coordinates, list) or len(raw_coordinates) < 3:
+        msg = "Polygon addition 'coordinates' must contain at least three points"
+        raise ValueError(msg)
+
+    return PolygonAdditionConfig(
+        label=str(block["label"]),
+        coordinates=[
+            _parse_xy(coordinate, "coordinates") for coordinate in raw_coordinates
+        ],
     )
 
 
@@ -548,6 +697,142 @@ def _generate_polygons(
     return polygons.reset_index(drop=True)
 
 
+def _apply_polygon_splits(
+    polygons: gpd.GeoDataFrame,
+    split_configs: list[PolygonSplitConfig],
+) -> gpd.GeoDataFrame:
+    """Split configured polygons using explicit floorplan cut lines."""
+    result = polygons.copy()
+
+    for split_config in split_configs:
+        selector = Point(split_config.selector_point)
+        matching_indices = result.index[result.geometry.covers(selector)]
+        if len(matching_indices) != 1:
+            msg = (
+                "Polygon split selector must identify exactly one polygon; "
+                f"found {len(matching_indices)}"
+            )
+            raise ValueError(msg)
+
+        source_index = matching_indices[0]
+        pieces: list[BaseGeometry] = [result.loc[source_index, "geometry"]]
+        for cut_line in split_config.cut_lines:
+            cutter = LineString(
+                [(cut_line[0], cut_line[1]), (cut_line[2], cut_line[3])]
+            )
+            pieces = [
+                part
+                for piece in pieces
+                for part in split(piece, cutter).geoms
+                if part.geom_type == "Polygon" and not part.is_empty
+            ]
+
+        if len(pieces) < 2:
+            msg = "Configured cut lines did not split the selected polygon"
+            raise ValueError(msg)
+
+        result = result.drop(index=source_index)
+        result = gpd.GeoDataFrame(
+            pd.concat(
+                [
+                    result,
+                    gpd.GeoDataFrame(geometry=pieces, crs=result.crs),
+                ],
+                ignore_index=True,
+            ),
+            geometry="geometry",
+            crs=result.crs,
+        )
+
+    return result.reset_index(drop=True)
+
+
+def _apply_polygon_additions(
+    polygons: gpd.GeoDataFrame,
+    addition_configs: list[PolygonAdditionConfig],
+) -> gpd.GeoDataFrame:
+    """Add explicitly configured polygons absent from source linework."""
+    additions = [Polygon(addition.coordinates) for addition in addition_configs]
+    if not additions:
+        return polygons
+    if not all(polygon.is_valid and polygon.area > 0 for polygon in additions):
+        msg = "Configured polygon additions must be valid positive-area polygons"
+        raise ValueError(msg)
+
+    return gpd.GeoDataFrame(
+        pd.concat(
+            [
+                polygons,
+                gpd.GeoDataFrame(geometry=additions, crs=polygons.crs),
+            ],
+            ignore_index=True,
+        ),
+        geometry="geometry",
+        crs=polygons.crs,
+    )
+
+
+def _apply_split_region_labels(
+    polygons: gpd.GeoDataFrame,
+    split_configs: list[PolygonSplitConfig],
+    polygon_label_target: str,
+) -> gpd.GeoDataFrame:
+    """Apply explicit labels to regions created by configured polygon splits."""
+    result = polygons.copy()
+
+    for split_config in split_configs:
+        for region in split_config.regions:
+            seed = Point(region.seed_point)
+            matching_indices = result.index[result.geometry.covers(seed)]
+            if len(matching_indices) != 1:
+                msg = (
+                    "Split region seed must identify exactly one polygon; "
+                    f"found {len(matching_indices)}"
+                )
+                raise ValueError(msg)
+
+            region_index = matching_indices[0]
+            result.loc[
+                region_index,
+                [polygon_label_target, "label_count", "label_ambiguous"],
+            ] = [region.label, 1, False]
+            result.loc[[region_index], "label_candidates"] = pd.Series(
+                [[region.label]],
+                index=[region_index],
+            )
+
+    return result
+
+
+def _apply_addition_labels(
+    polygons: gpd.GeoDataFrame,
+    addition_configs: list[PolygonAdditionConfig],
+    polygon_label_target: str,
+) -> gpd.GeoDataFrame:
+    """Apply labels to explicitly configured polygon additions."""
+    result = polygons.copy()
+    addition_count = len(addition_configs)
+    if addition_count == 0:
+        return result
+
+    addition_indices = result.index[-addition_count:]
+    for addition_index, addition in zip(
+        addition_indices,
+        addition_configs,
+        strict=True,
+    ):
+        result.loc[
+            addition_index,
+            [polygon_label_target, "label_count", "label_ambiguous"],
+        ] = [addition.label, 1, False]
+        result.loc[[addition_index], "label_candidates"] = pd.Series(
+            [[addition.label]],
+            index=[addition_index],
+        )
+
+    return result
+
+
 def _generate_room_numbers(
     gdf: gpd.GeoDataFrame,
     label_layer_name: str,
@@ -558,9 +843,10 @@ def _generate_room_numbers(
     """
     Extract and filter room label point geometries for a given floor.
 
-    Room labels are selected from a specific DXF layer and filtered by
-    a string prefix match on the label column. Any Z-coordinates present
-    on point geometries are removed.
+    Room labels are selected from a specific DXF layer. Multiline text is
+    normalised to the line beginning with the configured floor prefix before
+    exclusions are applied. Any Z-coordinates present on point geometries are
+    removed.
 
     Parameters
     ----------
@@ -581,16 +867,35 @@ def _generate_room_numbers(
         A GeoDataFrame containing filtered 2D room label point geometries.
 
     """
-    room_number_layer = gdf.loc[gdf["Layer"] == label_layer_name, :]
-    room_number_layer = room_number_layer.loc[
-        ~room_number_layer[polygon_label_column].isin(excluded_room_numbers), :
-    ]
+    room_number_layer = gdf.loc[
+        gdf["Layer"] == label_layer_name,
+        [polygon_label_column, "geometry"],
+    ].copy()
+    room_number_layer[polygon_label_column] = room_number_layer[
+        polygon_label_column
+    ].apply(lambda value: _extract_floor_label(value, floor_filter))
     room_numbers = room_number_layer.loc[
-        room_number_layer[polygon_label_column].str.startswith(floor_filter),
+        room_number_layer[polygon_label_column].notna()
+        & ~room_number_layer[polygon_label_column].isin(excluded_room_numbers),
         [polygon_label_column, "geometry"],
     ]
 
     return _flatten_z_points(room_numbers)
+
+
+def _extract_floor_label(value: object, floor_filter: str) -> str | None:
+    """Return the first trimmed label line matching the floor prefix."""
+    if not isinstance(value, str):
+        return None
+
+    return next(
+        (
+            line.strip()
+            for line in value.splitlines()
+            if line.strip().startswith(floor_filter)
+        ),
+        None,
+    )
 
 
 def _generate_doors(gdf: gpd.GeoDataFrame, target_layer: str) -> gpd.GeoDataFrame:
@@ -796,6 +1101,8 @@ def extract_polygons(
     gdf = gpd.read_file(input_dxf_path)
 
     polygons = _generate_polygons(gdf, config.polygons.polygon_layer_name)
+    polygons = _apply_polygon_splits(polygons, config.polygon_splits)
+    polygons = _apply_polygon_additions(polygons, config.polygon_additions)
 
     room_numbers = _generate_room_numbers(
         gdf,
@@ -809,6 +1116,16 @@ def extract_polygons(
         polygons,
         room_numbers,
         config.polygons.polygon_label_column,
+        config.polygons.polygon_label_target,
+    )
+    labelled_polygons = _apply_split_region_labels(
+        labelled_polygons,
+        config.polygon_splits,
+        config.polygons.polygon_label_target,
+    )
+    labelled_polygons = _apply_addition_labels(
+        labelled_polygons,
+        config.polygon_additions,
         config.polygons.polygon_label_target,
     )
 

--- a/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
+++ b/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
@@ -770,6 +770,14 @@ def extract_polygons(
             config.doors,
         )
 
-    return labelled_polygons.loc[
-        labelled_polygons[config.polygons.polygon_label_target].notna(), :
-    ]
+    labelled_polygons["has_label"] = labelled_polygons[
+        config.polygons.polygon_label_target
+    ].notna()
+
+    labelled_polygons["needs_review"] = (
+        ~labelled_polygons["has_label"]
+        | labelled_polygons.get("label_ambiguous", False)
+        | (labelled_polygons.get("door_count", 0) == 0)
+    )
+
+    return labelled_polygons

--- a/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
+++ b/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
@@ -30,15 +30,15 @@ internal helpers and are not part of the public API.
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import geopandas as gpd
 import pandas as pd
 import shapely
 import yaml
-from shapely.geometry import GeometryCollection
+from shapely.geometry import GeometryCollection, LineString, MultiLineString
 from shapely.geometry.base import BaseGeometry
-from shapely.ops import polygonize
+from shapely.ops import linemerge, polygonize, unary_union
 
 XY = tuple[float, float]
 DoorQuad = list[float]  # [x1, y1, x2, y2]
@@ -240,6 +240,58 @@ def _pair_points_to_quad(points: list[XY]) -> DoorQuad | None:
     return [x1, y1, x2, y2]
 
 
+def _line_to_xyxy(line: BaseGeometry) -> DoorQuad | None:
+    if line.is_empty:
+        return None
+
+    if isinstance(line, MultiLineString):
+        merged = linemerge(line)
+        if isinstance(merged, MultiLineString):
+            line = max(merged.geoms, key=lambda g: g.length)
+        else:
+            line = merged
+
+    if not isinstance(line, LineString):
+        return None
+
+    coords = list(line.coords)
+    if len(coords) < 2:
+        return None
+
+    x1, y1 = coords[0][:2]
+    x2, y2 = coords[-1][:2]
+
+    return [float(x1), float(y1), float(x2), float(y2)]
+
+
+def _combine_door_geometries(
+    doors: gpd.GeoDataFrame,
+    config: DoorAttachmentConfig,
+) -> gpd.GeoDataFrame:
+    rows = []
+
+    for entity_id, group in doors.groupby(config.entity_col, sort=False):
+        geom = unary_union(list(group.geometry))
+        geom = shapely.force_2d(geom)
+
+        if geom.length < config.min_door_length:
+            continue
+
+        door_quad = _line_to_xyxy(geom)
+        if door_quad is None:
+            continue
+
+        rows.append(
+            {
+                config.entity_col: entity_id,
+                "geometry": geom,
+                "door_xyxy": door_quad,
+            }
+        )
+
+    return gpd.GeoDataFrame(rows, geometry="geometry", crs=doors.crs)
+
+
 def attach_room_doors(
     labelled_polygons: gpd.GeoDataFrame,
     doors: gpd.GeoDataFrame,
@@ -276,12 +328,7 @@ def attach_room_doors(
     if config is None:
         config = DoorAttachmentConfig()
 
-    required_doors_cols = {
-        config.entity_col,
-        config.x_col,
-        config.y_col,
-        "geometry",
-    }
+    required_doors_cols = {config.entity_col, "geometry"}
     missing = required_doors_cols.difference(doors.columns)
     if missing:
         msg = f"doors is missing required columns: {sorted(missing)}"
@@ -291,39 +338,73 @@ def attach_room_doors(
         msg = "labelled_polygons must have a 'geometry' column"
         raise KeyError(msg)
 
-    joined = gpd.sjoin(
-        doors[[config.entity_col, config.x_col, config.y_col, "geometry"]],
-        labelled_polygons[["geometry"]],
-        how="inner",
-        predicate=config.predicate,
-    ).rename(columns={"index_right": "room_idx"})
+    combined_doors = _combine_door_geometries(doors, config)
 
-    points = joined.groupby(["room_idx", config.entity_col], sort=False)[
-        [config.x_col, config.y_col]
-    ].apply(
-        lambda df: list(
-            zip(
-                df[config.x_col].astype(float),
-                df[config.y_col].astype(float),
-                strict=True,
-            )
-        )
+    rooms = labelled_polygons.copy()
+    rooms["_room_idx"] = rooms.index
+    rooms["_boundary_geometry"] = rooms.geometry.boundary.buffer(
+        config.boundary_tolerance
     )
 
-    quads = points.apply(_pair_points_to_quad).dropna().rename("door_xyxy")
+    boundary_gdf = gpd.GeoDataFrame(
+        rooms[["_room_idx"]],
+        geometry=rooms["_boundary_geometry"],
+        crs=rooms.crs,
+    )
+
+    joined = gpd.sjoin(
+        combined_doors[[config.entity_col, "door_xyxy", "geometry"]],
+        boundary_gdf,
+        how="left",
+        predicate="intersects",
+    )
+
+    valid = joined.dropna(subset=["_room_idx"]).copy()
+    valid["_room_idx"] = valid["_room_idx"].astype(int)
+
+    attachments = (
+        valid.groupby(["_room_idx", config.entity_col], sort=False)["door_xyxy"]
+        .first()
+        .reset_index()
+    )
 
     doors_by_room = (
-        cast("pd.Series", quads)
-        .groupby(level=0, sort=False)
+        attachments.groupby("_room_idx", sort=False)["door_xyxy"]
         .apply(list)
         .rename(config.out_col)
     )
+
+    attachment_counts = (
+        valid.groupby(config.entity_col)["_room_idx"]
+        .nunique()
+        .rename("attached_room_count")
+    )
+
+    unresolved_doors = (
+        combined_doors[[config.entity_col]]
+        .merge(
+            attachment_counts,
+            left_on=config.entity_col,
+            right_index=True,
+            how="left",
+        )
+        .fillna({"attached_room_count": 0})
+    )
+
+    unresolved_doors["door_attachment_warning"] = (
+        unresolved_doors["attached_room_count"].astype(int) > config.max_attached_rooms
+    ) | (unresolved_doors["attached_room_count"].astype(int) == 0)
 
     result = labelled_polygons.copy()
     result = result.join(doors_by_room, how="left")
     result[config.out_col] = result[config.out_col].apply(
         lambda v: v if isinstance(v, list) else []
     )
+
+    result["door_count"] = result[config.out_col].apply(len)
+
+    result.attrs["door_attachment_report"] = unresolved_doors.to_dict(orient="records")
+
     return result
 
 

--- a/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
+++ b/python-code/src/floorplan_extractor/dxf_polygon_extraction.py
@@ -15,7 +15,10 @@ Typical workflow:
 2. Polygonise linework from a specified DXF layer.
 3. Extract room label point geometries from another layer.
 4. Filter labels by floor using a string prefix.
-5. Spatially join labels to polygons and aggregate them deterministically.
+5. Apply configured polygon corrections.
+6. Spatially join labels to polygons and aggregate them deterministically.
+7. Normalise accepted shared walls to common midlines.
+8. Project door symbols onto the final room boundaries.
 
 The module makes the following assumptions:
 - DXF layer names are stable and known in advance.
@@ -89,20 +92,27 @@ class PolygonExtractionConfig:
 @dataclass(frozen=True)
 class DoorAttachmentConfig:
     """
-    Configuration for extracting and attaching paired door endpoints.
+    Configuration for extracting and attaching canonical door segments.
 
     Attributes
     ----------
     entity_col : str
-        Column linking the two rows that represent the same door.
+        Column linking the CAD geometries that represent the same door.
     x_col : str
-        Column containing centroid x coordinates.
+        Column containing centroid x coordinates retained for compatibility.
     y_col : str
-        Column containing centroid y coordinates.
+        Column containing centroid y coordinates retained for compatibility.
     out_col : str
         Name of the output column added to the room polygons.
     predicate : str
-        Spatial predicate passed to ``geopandas.sjoin``.
+        Spatial predicate retained for configuration compatibility.
+    boundary_tolerance : float
+        Maximum distance from a room-boundary segment used when projecting
+        source door geometry.
+    min_door_length : float
+        Minimum projected door length to retain.
+    max_attached_rooms : int
+        Maximum expected number of rooms connected by one door.
 
     """
 
@@ -668,7 +678,13 @@ def attach_room_doors(
     config: DoorAttachmentConfig | None = None,
 ) -> gpd.GeoDataFrame:
     """
-    Attach paired door endpoint coordinates to room polygons.
+    Project CAD door geometry onto room boundaries and attach the segments.
+
+    Source geometries belonging to the same door are combined using
+    ``config.entity_col``. Candidate spans are projected onto straight
+    exterior segments of the final room polygons. The preferred projection is
+    the segment shared by the greatest number of rooms, with projected length
+    used as a secondary ranking criterion.
 
     Parameters
     ----------
@@ -686,7 +702,8 @@ def attach_room_doors(
     geopandas.GeoDataFrame
         Copy of ``labelled_polygons`` with an added column ``config.out_col``.
         Each value is a list of ``[x1, y1, x2, y2]`` lists. Rooms with no doors
-        contain an empty list.
+        contain an empty list. Attachment diagnostics are stored in
+        ``result.attrs["door_attachment_report"]``.
 
     Raises
     ------
@@ -1309,9 +1326,10 @@ def extract_polygons(
     """
     Extract labelled polygons from a DXF floorplan.
 
-    The DXF file is read into a GeoDataFrame, polygon geometries are
-    generated from linework, room label points are filtered by floor,
-    and labels are spatially joined to the resulting polygons.
+    The DXF file is read into a GeoDataFrame, polygon geometries are generated
+    from linework, and room labels are filtered and attached. Configured
+    polygon corrections are applied before optional shared-wall
+    normalisation and canonical door projection.
 
     Parameters
     ----------
@@ -1324,7 +1342,9 @@ def extract_polygons(
     Returns
     -------
     geopandas.GeoDataFrame
-        A GeoDataFrame containing labelled polygon geometries.
+        Labelled room polygons with extraction metadata. The columns include
+        ``has_label`` and ``needs_review``. Door and shared-wall columns are
+        included when their corresponding configuration blocks are enabled.
 
     """
     gdf = gpd.read_file(input_dxf_path)

--- a/python-code/src/floorplan_extractor/shared_walls.py
+++ b/python-code/src/floorplan_extractor/shared_walls.py
@@ -6,17 +6,25 @@ from itertools import combinations, pairwise
 from math import atan2, cos, pi, radians, sin
 
 import geopandas as gpd
+import shapely
 from shapely.geometry import LineString, Point, Polygon
 
 XY = tuple[float, float]
-SegmentReplacement = tuple[XY, XY, XY, XY]
+SegmentReplacement = tuple[float, XY, XY, XY, XY]
 MIN_SEGMENT_COORDINATES = 2
 GEOMETRY_TOLERANCE = 1e-9
+COORDINATE_TOLERANCE = 1e-6
+BOUNDARY_COVERAGE_TOLERANCE = 1e-4
+MIN_BOUNDARY_COVERAGE_RATIO = 0.99
+MAX_REPAIR_AREA_RELATIVE_DIFFERENCE = 1e-9
+MAX_ATTR_REJECTIONS = 1000
 REVIEW_REJECTION_REASONS: frozenset[str] = frozenset(
     {
         "ambiguous_match",
+        "gap_too_small",
         "insufficient_overlap_length",
         "insufficient_overlap_ratio",
+        "normalisation_invalid_geometry",
         "third_room_intersection",
     }
 )
@@ -83,6 +91,8 @@ class SharedWallCandidate:
     overlap_length: float
     overlap_ratio: float
     overlap: tuple[float, float]
+    first_interval: tuple[float, float]
+    second_interval: tuple[float, float]
     strip: Polygon
 
 
@@ -97,6 +107,16 @@ class SharedWallRejection:
     overlap_length: float | None = None
     overlap_ratio: float | None = None
     blocking_room_id: Hashable | None = None
+
+
+@dataclass(frozen=True)
+class SharedWallPairMetrics:
+    """Geometric measurements for a paired wall-face comparison."""
+
+    gap: float
+    overlap: tuple[float, float]
+    overlap_length: float
+    overlap_ratio: float
 
 
 @dataclass(frozen=True)
@@ -142,6 +162,12 @@ def detect_shared_wall_candidates(
         elif rejection is not None:
             rejections.append(rejection)
 
+    candidates, overlap_rejections = _reject_insufficient_overlap_candidates(
+        candidates,
+        config.min_overlap_ratio,
+    )
+    rejections.extend(overlap_rejections)
+
     accepted, ambiguity_rejections = _reject_ambiguous_candidates(candidates)
     rejections.extend(ambiguity_rejections)
 
@@ -182,10 +208,78 @@ def normalise_shared_walls(
         )
 
     if config.enabled and detection.candidates:
-        replacements = _candidate_replacements(detection.candidates)
-        result.geometry = _normalised_geometry(result, replacements)
+        result.geometry, applied_candidates, application_rejections = (
+            _normalised_geometry(result, detection.candidates)
+        )
+        detection = SharedWallDetectionResult(
+            candidates=applied_candidates,
+            rejections=[*detection.rejections, *application_rejections],
+        )
 
     return _attach_review_metadata(result, detection)
+
+
+def candidate_midline(candidate: SharedWallCandidate) -> LineString:
+    """
+    Return the canonical midline for an accepted shared-wall candidate.
+
+    Parameters
+    ----------
+    candidate : SharedWallCandidate
+        Candidate whose paired wall-face overlap should be represented.
+
+    Returns
+    -------
+    shapely.geometry.LineString
+        Line segment halfway between the paired overlapping wall faces.
+
+    """
+    first_start, first_end, second_start, second_end = _candidate_overlap_points(
+        candidate
+    )
+
+    return LineString(
+        [
+            _midpoint(first_start, second_start),
+            _midpoint(first_end, second_end),
+        ]
+    )
+
+
+def rejection_overlap_lines(
+    rejection: SharedWallRejection,
+) -> tuple[LineString, LineString]:
+    """
+    Return source-wall lines clipped to a rejected pair's projected overlap.
+
+    Parameters
+    ----------
+    rejection : SharedWallRejection
+        Rejected wall-face pair to represent.
+
+    Returns
+    -------
+    tuple[shapely.geometry.LineString, shapely.geometry.LineString]
+        Corresponding overlap portions on the first and second wall faces.
+
+    """
+    overlap = _projected_overlap(rejection.first, rejection.second)
+    axis = _unit_axis(rejection.first)
+
+    return (
+        LineString(
+            [
+                _point_at_axis_projection(rejection.first, axis, overlap[0]),
+                _point_at_axis_projection(rejection.first, axis, overlap[1]),
+            ]
+        ),
+        LineString(
+            [
+                _point_at_axis_projection(rejection.second, axis, overlap[0]),
+                _point_at_axis_projection(rejection.second, axis, overlap[1]),
+            ]
+        ),
+    )
 
 
 def _extract_wall_segments(rooms: gpd.GeoDataFrame) -> list[WallSegment]:
@@ -233,42 +327,68 @@ def _evaluate_pair(
         return None, None
 
     gap = _perpendicular_gap(first, second)
-    if gap < config.min_gap or gap > config.max_gap:
-        return None, SharedWallRejection(first, second, "gap_out_of_range", gap=gap)
+    if gap > config.max_gap:
+        return None, SharedWallRejection(first, second, "gap_too_large", gap=gap)
 
     overlap = _projected_overlap(first, second)
     overlap_length = overlap[1] - overlap[0]
     overlap_ratio = overlap_length / min(first.length, second.length)
-    if overlap_length < config.min_overlap_length:
+    if overlap_length <= GEOMETRY_TOLERANCE:
+        return None, None
+
+    metrics = SharedWallPairMetrics(
+        gap=gap,
+        overlap=overlap,
+        overlap_length=overlap_length,
+        overlap_ratio=overlap_ratio,
+    )
+
+    if gap < config.min_gap:
+        return None, SharedWallRejection(
+            first,
+            second,
+            "gap_too_small",
+            gap=metrics.gap,
+            overlap_length=metrics.overlap_length,
+            overlap_ratio=metrics.overlap_ratio,
+        )
+
+    return _evaluate_overlapping_pair(
+        first,
+        second,
+        rooms,
+        config,
+        metrics,
+    )
+
+
+def _evaluate_overlapping_pair(
+    first: WallSegment,
+    second: WallSegment,
+    rooms: gpd.GeoDataFrame,
+    config: SharedWallConfig,
+    metrics: SharedWallPairMetrics,
+) -> tuple[SharedWallCandidate | None, SharedWallRejection | None]:
+    if metrics.overlap_length < config.min_overlap_length:
         return None, SharedWallRejection(
             first,
             second,
             "insufficient_overlap_length",
-            gap=gap,
-            overlap_length=overlap_length,
-            overlap_ratio=overlap_ratio,
+            gap=metrics.gap,
+            overlap_length=metrics.overlap_length,
+            overlap_ratio=metrics.overlap_ratio,
         )
 
-    if overlap_ratio < config.min_overlap_ratio:
-        return None, SharedWallRejection(
-            first,
-            second,
-            "insufficient_overlap_ratio",
-            gap=gap,
-            overlap_length=overlap_length,
-            overlap_ratio=overlap_ratio,
-        )
-
-    strip = _overlap_strip(first, second, overlap)
+    strip = _overlap_strip(first, second, metrics.overlap)
     blocking_room_id = _blocking_room_id(rooms, strip, {first.room_id, second.room_id})
     if blocking_room_id is not None:
         return None, SharedWallRejection(
             first,
             second,
             "third_room_intersection",
-            gap=gap,
-            overlap_length=overlap_length,
-            overlap_ratio=overlap_ratio,
+            gap=metrics.gap,
+            overlap_length=metrics.overlap_length,
+            overlap_ratio=metrics.overlap_ratio,
             blocking_room_id=blocking_room_id,
         )
 
@@ -276,10 +396,16 @@ def _evaluate_pair(
         SharedWallCandidate(
             first=first,
             second=second,
-            gap=gap,
-            overlap_length=overlap_length,
-            overlap_ratio=overlap_ratio,
-            overlap=overlap,
+            gap=metrics.gap,
+            overlap_length=metrics.overlap_length,
+            overlap_ratio=metrics.overlap_ratio,
+            overlap=metrics.overlap,
+            first_interval=_segment_interval(first, metrics.overlap, _unit_axis(first)),
+            second_interval=_segment_interval(
+                second,
+                metrics.overlap,
+                _unit_axis(first),
+            ),
             strip=strip,
         ),
         None,
@@ -321,10 +447,11 @@ def _overlap_strip(
     second: WallSegment,
     overlap: tuple[float, float],
 ) -> Polygon:
-    first_start = _point_at_projection(first, overlap[0])
-    first_end = _point_at_projection(first, overlap[1])
-    second_start = _point_at_projection(second, overlap[0])
-    second_end = _point_at_projection(second, overlap[1])
+    axis = _unit_axis(first)
+    first_start = _point_at_axis_projection(first, axis, overlap[0])
+    first_end = _point_at_axis_projection(first, axis, overlap[1])
+    second_start = _point_at_axis_projection(second, axis, overlap[0])
+    second_end = _point_at_axis_projection(second, axis, overlap[1])
 
     return Polygon([first_start, first_end, second_end, second_start])
 
@@ -334,33 +461,100 @@ def _blocking_room_id(
     strip: Polygon,
     paired_room_ids: set[Hashable],
 ) -> Hashable | None:
+    if not strip.is_valid:
+        strip = shapely.make_valid(strip)
+
     for room_id, geometry in rooms.geometry.items():
         if room_id in paired_room_ids:
             continue
 
-        intersection = geometry.intersection(strip)
+        room_geometry = (
+            shapely.make_valid(geometry) if not geometry.is_valid else geometry
+        )
+
+        intersection = room_geometry.intersection(strip)
         if intersection.area > GEOMETRY_TOLERANCE:
             return room_id
 
     return None
 
 
-def _reject_ambiguous_candidates(
+def _reject_insufficient_overlap_candidates(
     candidates: list[SharedWallCandidate],
+    min_overlap_ratio: float,
 ) -> tuple[list[SharedWallCandidate], list[SharedWallRejection]]:
-    segment_counts: dict[tuple[Hashable, int], int] = {}
+    candidates_by_segment: dict[tuple[Hashable, int], list[SharedWallCandidate]] = {}
     for candidate in candidates:
-        for key in (candidate.first.key, candidate.second.key):
-            segment_counts[key] = segment_counts.get(key, 0) + 1
+        candidates_by_segment.setdefault(candidate.first.key, []).append(candidate)
+        candidates_by_segment.setdefault(candidate.second.key, []).append(candidate)
 
     accepted: list[SharedWallCandidate] = []
     rejections: list[SharedWallRejection] = []
 
     for candidate in candidates:
-        if (
-            segment_counts[candidate.first.key] == 1
-            and segment_counts[candidate.second.key] == 1
+        if candidate.overlap_ratio >= min_overlap_ratio or any(
+            _aggregate_overlap_ratio(segment, candidates_by_segment[segment.key])
+            >= min_overlap_ratio
+            for segment in (candidate.first, candidate.second)
         ):
+            accepted.append(candidate)
+            continue
+
+        rejections.append(
+            SharedWallRejection(
+                first=candidate.first,
+                second=candidate.second,
+                reason="insufficient_overlap_ratio",
+                gap=candidate.gap,
+                overlap_length=candidate.overlap_length,
+                overlap_ratio=candidate.overlap_ratio,
+            )
+        )
+
+    return accepted, rejections
+
+
+def _aggregate_overlap_ratio(
+    segment: WallSegment,
+    candidates: list[SharedWallCandidate],
+) -> float:
+    intervals = [
+        (
+            candidate.first_interval
+            if candidate.first.key == segment.key
+            else candidate.second_interval
+        )
+        for candidate in candidates
+    ]
+
+    return _merged_interval_length(intervals) / segment.length
+
+
+def _merged_interval_length(intervals: list[tuple[float, float]]) -> float:
+    merged: list[tuple[float, float]] = []
+    for start, end in sorted(intervals):
+        if not merged or start > merged[-1][1] + GEOMETRY_TOLERANCE:
+            merged.append((start, end))
+            continue
+
+        merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+
+    return sum(end - start for start, end in merged)
+
+
+def _reject_ambiguous_candidates(
+    candidates: list[SharedWallCandidate],
+) -> tuple[list[SharedWallCandidate], list[SharedWallRejection]]:
+    candidates_by_segment: dict[tuple[Hashable, int], list[SharedWallCandidate]] = {}
+    for candidate in candidates:
+        candidates_by_segment.setdefault(candidate.first.key, []).append(candidate)
+        candidates_by_segment.setdefault(candidate.second.key, []).append(candidate)
+
+    accepted: list[SharedWallCandidate] = []
+    rejections: list[SharedWallRejection] = []
+
+    for candidate in candidates:
+        if not _has_overlapping_competitor(candidate, candidates_by_segment):
             accepted.append(candidate)
             continue
 
@@ -378,15 +572,44 @@ def _reject_ambiguous_candidates(
     return accepted, rejections
 
 
+def _has_overlapping_competitor(
+    candidate: SharedWallCandidate,
+    candidates_by_segment: dict[tuple[Hashable, int], list[SharedWallCandidate]],
+) -> bool:
+    for segment, interval in (
+        (candidate.first, candidate.first_interval),
+        (candidate.second, candidate.second_interval),
+    ):
+        for competitor in candidates_by_segment[segment.key]:
+            if competitor is candidate:
+                continue
+
+            competitor_interval = (
+                competitor.first_interval
+                if competitor.first.key == segment.key
+                else competitor.second_interval
+            )
+            if (
+                _interval_overlap_length(interval, competitor_interval)
+                > GEOMETRY_TOLERANCE
+            ):
+                return True
+
+    return False
+
+
 def _candidate_replacements(
     candidates: list[SharedWallCandidate],
-) -> dict[tuple[Hashable, int], SegmentReplacement]:
-    replacements: dict[tuple[Hashable, int], SegmentReplacement] = {}
+) -> dict[tuple[Hashable, int], list[SegmentReplacement]]:
+    replacements: dict[tuple[Hashable, int], list[SegmentReplacement]] = {}
 
     for candidate in candidates:
         first_midline, second_midline = _midline_replacements(candidate)
-        replacements[candidate.first.key] = first_midline
-        replacements[candidate.second.key] = second_midline
+        replacements.setdefault(candidate.first.key, []).append(first_midline)
+        replacements.setdefault(candidate.second.key, []).append(second_midline)
+
+    for segment_replacements in replacements.values():
+        segment_replacements.sort(key=lambda r: r[0])
 
     return replacements
 
@@ -394,10 +617,9 @@ def _candidate_replacements(
 def _midline_replacements(
     candidate: SharedWallCandidate,
 ) -> tuple[SegmentReplacement, SegmentReplacement]:
-    first_start = _point_at_projection(candidate.first, candidate.overlap[0])
-    first_end = _point_at_projection(candidate.first, candidate.overlap[1])
-    second_start = _point_at_projection(candidate.second, candidate.overlap[0])
-    second_end = _point_at_projection(candidate.second, candidate.overlap[1])
+    first_start, first_end, second_start, second_end = _candidate_overlap_points(
+        candidate
+    )
 
     midline = (
         _midpoint(first_start, second_start),
@@ -419,32 +641,132 @@ def _orient_replacement(
     end_distance = segment.line.project(Point(overlap[1]))
 
     if start_distance <= end_distance:
-        return (overlap[0], midline[0], midline[1], overlap[1])
+        return (start_distance, overlap[0], midline[0], midline[1], overlap[1])
 
-    return (overlap[1], midline[1], midline[0], overlap[0])
+    return (end_distance, overlap[1], midline[1], midline[0], overlap[0])
 
 
 def _normalised_geometry(
     rooms: gpd.GeoDataFrame,
-    replacements: dict[tuple[Hashable, int], SegmentReplacement],
-) -> gpd.GeoSeries:
+    candidates: list[SharedWallCandidate],
+) -> tuple[
+    gpd.GeoSeries,
+    list[SharedWallCandidate],
+    list[SharedWallRejection],
+]:
     geometries = rooms.geometry.copy()
+    candidates_by_room: dict[Hashable, list[SharedWallCandidate]] = {
+        room_id: [] for room_id in rooms.index
+    }
+    applied: list[SharedWallCandidate] = []
+    rejections: list[SharedWallRejection] = []
 
-    for room_id, geometry in rooms.geometry.items():
-        if not isinstance(geometry, Polygon) or geometry.is_empty:
+    ordered_candidates = sorted(
+        candidates,
+        key=lambda candidate: (
+            -candidate.overlap_length,
+            -candidate.overlap_ratio,
+            candidate.gap,
+        ),
+    )
+    for candidate in ordered_candidates:
+        room_ids = (candidate.first.room_id, candidate.second.room_id)
+        updated: dict[Hashable, Polygon] = {}
+
+        for room_id in room_ids:
+            geometry = rooms.geometry.loc[room_id]
+            if not isinstance(geometry, Polygon) or geometry.is_empty:
+                break
+
+            room_candidates = [*candidates_by_room[room_id], candidate]
+            replacements = _candidate_replacements(room_candidates)
+            polygon = _normalise_polygon(room_id, geometry, replacements)
+            if not polygon.is_valid:
+                repaired = _repair_normalised_polygon(polygon, room_candidates)
+                if repaired is None:
+                    break
+                polygon = repaired
+
+            if polygon.area <= GEOMETRY_TOLERANCE:
+                break
+
+            updated[room_id] = polygon
+        else:
+            applied.append(candidate)
+            for room_id, polygon in updated.items():
+                candidates_by_room[room_id].append(candidate)
+                geometries.loc[room_id] = polygon
             continue
 
-        updated = _normalise_polygon(room_id, geometry, replacements)
-        if updated.is_valid and updated.area > GEOMETRY_TOLERANCE:
-            geometries.loc[room_id] = updated
+        rejections.append(
+            SharedWallRejection(
+                first=candidate.first,
+                second=candidate.second,
+                reason="normalisation_invalid_geometry",
+                gap=candidate.gap,
+                overlap_length=candidate.overlap_length,
+                overlap_ratio=candidate.overlap_ratio,
+            )
+        )
 
-    return geometries
+    return geometries, applied, rejections
+
+
+def _repair_normalised_polygon(
+    polygon: Polygon,
+    candidates: list[SharedWallCandidate],
+) -> Polygon | None:
+    repaired = shapely.make_valid(polygon)
+    polygons = _polygon_parts(repaired)
+    if len(polygons) != 1:
+        return None
+
+    repaired_polygon = polygons[0]
+    area_tolerance = max(1.0, polygon.area) * MAX_REPAIR_AREA_RELATIVE_DIFFERENCE
+    if abs(repaired_polygon.area - polygon.area) > area_tolerance:
+        return None
+
+    if not all(
+        _boundary_contains_midline(repaired_polygon, candidate)
+        for candidate in candidates
+    ):
+        return None
+
+    return repaired_polygon
+
+
+def _polygon_parts(geometry: shapely.Geometry) -> list[Polygon]:
+    if isinstance(geometry, Polygon):
+        return [geometry]
+    if not hasattr(geometry, "geoms"):
+        return []
+
+    return [
+        polygon for component in geometry.geoms for polygon in _polygon_parts(component)
+    ]
+
+
+def _boundary_contains_midline(
+    polygon: Polygon,
+    candidate: SharedWallCandidate,
+) -> bool:
+    midline = candidate_midline(candidate)
+    if midline.length <= GEOMETRY_TOLERANCE:
+        return True
+
+    covered_length = (
+        polygon.boundary.buffer(BOUNDARY_COVERAGE_TOLERANCE)
+        .intersection(midline)
+        .length
+    )
+
+    return covered_length / midline.length >= MIN_BOUNDARY_COVERAGE_RATIO
 
 
 def _normalise_polygon(
     room_id: Hashable,
     polygon: Polygon,
-    replacements: dict[tuple[Hashable, int], SegmentReplacement],
+    replacements: dict[tuple[Hashable, int], list[SegmentReplacement]],
 ) -> Polygon:
     coords = [_xy(coord) for coord in polygon.exterior.coords]
     if len(coords) < 2:
@@ -455,20 +777,23 @@ def _normalise_polygon(
         if not updated:
             updated.append(start)
 
-        replacement = replacements.get((room_id, segment_index))
-        if replacement is None:
-            updated.append(end)
+        segment_replacements = replacements.get((room_id, segment_index))
+        if segment_replacements is None:
+            _append_distinct(updated, end)
             continue
 
-        overlap_start, mid_start, mid_end, overlap_end = replacement
-        _append_distinct(updated, overlap_start)
-        _append_distinct(updated, mid_start)
-        _append_distinct(updated, mid_end)
-        _append_distinct(updated, overlap_end)
+        for replacement in segment_replacements:
+            _, overlap_start, mid_start, mid_end, overlap_end = replacement
+            _append_distinct(updated, overlap_start)
+            _append_distinct(updated, mid_start)
+            _append_distinct(updated, mid_end)
+            _append_distinct(updated, overlap_end)
         _append_distinct(updated, end)
 
-    if updated[0] != updated[-1]:
+    if not _coords_close(updated[0], updated[-1]):
         updated.append(updated[0])
+    else:
+        updated[-1] = updated[0]
 
     return Polygon(updated, holes=list(polygon.interiors))
 
@@ -503,6 +828,14 @@ def _attach_review_metadata(
     result["shared_wall_review"] = [
         bool(rejections.get(room_id, [])) for room_id in result.index
     ]
+    result.attrs["shared_wall_detection"] = SharedWallDetectionResult(
+        candidates=detection.candidates,
+        rejections=[
+            rejection
+            for rejection in detection.rejections
+            if rejection.reason in REVIEW_REJECTION_REASONS
+        ][:MAX_ATTR_REJECTIONS],
+    )
 
     return result
 
@@ -530,14 +863,67 @@ def _projection_range(
     return (min(projections), max(projections))
 
 
-def _point_at_projection(segment: WallSegment, projection: float) -> XY:
-    axis = _unit_axis(segment)
-    origin_projection = _dot(segment.start, axis)
-    distance = projection - origin_projection
+def _segment_interval(
+    segment: WallSegment,
+    overlap: tuple[float, float],
+    projection_axis: tuple[float, float],
+) -> tuple[float, float]:
+    overlap_start = _point_at_axis_projection(
+        segment,
+        projection_axis,
+        overlap[0],
+    )
+    overlap_end = _point_at_axis_projection(
+        segment,
+        projection_axis,
+        overlap[1],
+    )
+
+    return tuple(
+        sorted(
+            (
+                segment.line.project(Point(overlap_start)),
+                segment.line.project(Point(overlap_end)),
+            )
+        )
+    )
+
+
+def _interval_overlap_length(
+    first: tuple[float, float],
+    second: tuple[float, float],
+) -> float:
+    overlap_start = max(first[0], second[0])
+    overlap_end = min(first[1], second[1])
+
+    return max(0.0, overlap_end - overlap_start)
+
+
+def _candidate_overlap_points(
+    candidate: SharedWallCandidate,
+) -> tuple[XY, XY, XY, XY]:
+    axis = _unit_axis(candidate.first)
 
     return (
-        segment.start[0] + axis[0] * distance,
-        segment.start[1] + axis[1] * distance,
+        _point_at_axis_projection(candidate.first, axis, candidate.overlap[0]),
+        _point_at_axis_projection(candidate.first, axis, candidate.overlap[1]),
+        _point_at_axis_projection(candidate.second, axis, candidate.overlap[0]),
+        _point_at_axis_projection(candidate.second, axis, candidate.overlap[1]),
+    )
+
+
+def _point_at_axis_projection(
+    segment: WallSegment,
+    projection_axis: tuple[float, float],
+    projection: float,
+) -> XY:
+    segment_axis = _unit_axis(segment)
+    axis_alignment = _dot(segment_axis, projection_axis)
+    distance = (projection - _dot(segment.start, projection_axis)) / axis_alignment
+
+    return (
+        segment.start[0] + segment_axis[0] * distance,
+        segment.start[1] + segment_axis[1] * distance,
     )
 
 
@@ -561,5 +947,12 @@ def _midpoint(first: XY, second: XY) -> XY:
 
 
 def _append_distinct(coords: list[XY], point: XY) -> None:
-    if coords[-1] != point:
+    if not _coords_close(coords[-1], point):
         coords.append(point)
+
+
+def _coords_close(first: XY, second: XY) -> bool:
+    return (
+        abs(first[0] - second[0]) <= COORDINATE_TOLERANCE
+        and abs(first[1] - second[1]) <= COORDINATE_TOLERANCE
+    )

--- a/python-code/src/floorplan_extractor/shared_walls.py
+++ b/python-code/src/floorplan_extractor/shared_walls.py
@@ -6,13 +6,22 @@ from itertools import combinations, pairwise
 from math import atan2, cos, pi, radians, sin
 
 import geopandas as gpd
-from shapely.geometry import LineString, Polygon
+from shapely.geometry import LineString, Point, Polygon
 
 from floorplan_extractor.dxf_polygon_extraction import SharedWallConfig
 
 XY = tuple[float, float]
+SegmentReplacement = tuple[XY, XY, XY, XY]
 MIN_SEGMENT_COORDINATES = 2
 GEOMETRY_TOLERANCE = 1e-9
+REVIEW_REJECTION_REASONS: frozenset[str] = frozenset(
+    {
+        "ambiguous_match",
+        "insufficient_overlap_length",
+        "insufficient_overlap_ratio",
+        "third_room_intersection",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -42,6 +51,7 @@ class SharedWallCandidate:
     gap: float
     overlap_length: float
     overlap_ratio: float
+    overlap: tuple[float, float]
     strip: Polygon
 
 
@@ -105,6 +115,46 @@ def detect_shared_wall_candidates(
     rejections.extend(ambiguity_rejections)
 
     return SharedWallDetectionResult(candidates=accepted, rejections=rejections)
+
+
+def normalise_shared_walls(
+    rooms: gpd.GeoDataFrame,
+    config: SharedWallConfig,
+    detection: SharedWallDetectionResult | None = None,
+) -> gpd.GeoDataFrame:
+    """
+    Move accepted shared wall-face overlaps to a common midline.
+
+    Parameters
+    ----------
+    rooms : geopandas.GeoDataFrame
+        Labelled room polygons to normalise.
+    config : SharedWallConfig
+        Shared-wall configuration. If disabled, geometries are not changed.
+    detection : SharedWallDetectionResult or None
+        Candidate detection output. If omitted and config is enabled, detection
+        is run using ``rooms`` and ``config``.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        A copy of ``rooms`` with updated geometries and shared-wall metadata.
+
+    """
+    result = rooms.copy()
+
+    if detection is None:
+        detection = (
+            detect_shared_wall_candidates(rooms, config)
+            if config.enabled
+            else SharedWallDetectionResult(candidates=[], rejections=[])
+        )
+
+    if config.enabled and detection.candidates:
+        replacements = _candidate_replacements(detection.candidates)
+        result.geometry = _normalised_geometry(result, replacements)
+
+    return _attach_review_metadata(result, detection)
 
 
 def _extract_wall_segments(rooms: gpd.GeoDataFrame) -> list[WallSegment]:
@@ -198,6 +248,7 @@ def _evaluate_pair(
             gap=gap,
             overlap_length=overlap_length,
             overlap_ratio=overlap_ratio,
+            overlap=overlap,
             strip=strip,
         ),
         None,
@@ -296,6 +347,149 @@ def _reject_ambiguous_candidates(
     return accepted, rejections
 
 
+def _candidate_replacements(
+    candidates: list[SharedWallCandidate],
+) -> dict[tuple[Hashable, int], SegmentReplacement]:
+    replacements: dict[tuple[Hashable, int], SegmentReplacement] = {}
+
+    for candidate in candidates:
+        first_midline, second_midline = _midline_replacements(candidate)
+        replacements[candidate.first.key] = first_midline
+        replacements[candidate.second.key] = second_midline
+
+    return replacements
+
+
+def _midline_replacements(
+    candidate: SharedWallCandidate,
+) -> tuple[SegmentReplacement, SegmentReplacement]:
+    first_start = _point_at_projection(candidate.first, candidate.overlap[0])
+    first_end = _point_at_projection(candidate.first, candidate.overlap[1])
+    second_start = _point_at_projection(candidate.second, candidate.overlap[0])
+    second_end = _point_at_projection(candidate.second, candidate.overlap[1])
+
+    midline = (
+        _midpoint(first_start, second_start),
+        _midpoint(first_end, second_end),
+    )
+
+    return (
+        _orient_replacement(candidate.first, (first_start, first_end), midline),
+        _orient_replacement(candidate.second, (second_start, second_end), midline),
+    )
+
+
+def _orient_replacement(
+    segment: WallSegment,
+    overlap: tuple[XY, XY],
+    midline: tuple[XY, XY],
+) -> SegmentReplacement:
+    start_distance = segment.line.project(Point(overlap[0]))
+    end_distance = segment.line.project(Point(overlap[1]))
+
+    if start_distance <= end_distance:
+        return (overlap[0], midline[0], midline[1], overlap[1])
+
+    return (overlap[1], midline[1], midline[0], overlap[0])
+
+
+def _normalised_geometry(
+    rooms: gpd.GeoDataFrame,
+    replacements: dict[tuple[Hashable, int], SegmentReplacement],
+) -> gpd.GeoSeries:
+    geometries = rooms.geometry.copy()
+
+    for room_id, geometry in rooms.geometry.items():
+        if not isinstance(geometry, Polygon) or geometry.is_empty:
+            continue
+
+        updated = _normalise_polygon(room_id, geometry, replacements)
+        if updated.is_valid and updated.area > GEOMETRY_TOLERANCE:
+            geometries.loc[room_id] = updated
+
+    return geometries
+
+
+def _normalise_polygon(
+    room_id: Hashable,
+    polygon: Polygon,
+    replacements: dict[tuple[Hashable, int], SegmentReplacement],
+) -> Polygon:
+    coords = [_xy(coord) for coord in polygon.exterior.coords]
+    if len(coords) < 2:
+        return polygon
+
+    updated: list[XY] = []
+    for segment_index, (start, end) in enumerate(pairwise(coords)):
+        if not updated:
+            updated.append(start)
+
+        replacement = replacements.get((room_id, segment_index))
+        if replacement is None:
+            updated.append(end)
+            continue
+
+        overlap_start, mid_start, mid_end, overlap_end = replacement
+        _append_distinct(updated, overlap_start)
+        _append_distinct(updated, mid_start)
+        _append_distinct(updated, mid_end)
+        _append_distinct(updated, overlap_end)
+        _append_distinct(updated, end)
+
+    if updated[0] != updated[-1]:
+        updated.append(updated[0])
+
+    return Polygon(updated, holes=list(polygon.interiors))
+
+
+def _attach_review_metadata(
+    rooms: gpd.GeoDataFrame,
+    detection: SharedWallDetectionResult,
+) -> gpd.GeoDataFrame:
+    result = rooms.copy()
+    counts: dict[Hashable, int] = dict.fromkeys(result.index, 0)
+    rejections: dict[Hashable, list[dict[str, object]]] = {
+        room_id: [] for room_id in result.index
+    }
+
+    for candidate in detection.candidates:
+        counts[candidate.first.room_id] = counts.get(candidate.first.room_id, 0) + 1
+        counts[candidate.second.room_id] = counts.get(candidate.second.room_id, 0) + 1
+
+    for rejection in detection.rejections:
+        if rejection.reason not in REVIEW_REJECTION_REASONS:
+            continue
+
+        rejection_summary = _rejection_summary(rejection)
+        for room_id in (rejection.first.room_id, rejection.second.room_id):
+            if room_id in rejections:
+                rejections[room_id].append(rejection_summary)
+
+    result["shared_wall_count"] = [counts.get(room_id, 0) for room_id in result.index]
+    result["shared_wall_rejections"] = [
+        rejections.get(room_id, []) for room_id in result.index
+    ]
+    result["shared_wall_review"] = [
+        bool(rejections.get(room_id, [])) for room_id in result.index
+    ]
+
+    return result
+
+
+def _rejection_summary(rejection: SharedWallRejection) -> dict[str, object]:
+    return {
+        "reason": rejection.reason,
+        "first_room_id": rejection.first.room_id,
+        "first_segment_index": rejection.first.segment_index,
+        "second_room_id": rejection.second.room_id,
+        "second_segment_index": rejection.second.segment_index,
+        "gap": rejection.gap,
+        "overlap_length": rejection.overlap_length,
+        "overlap_ratio": rejection.overlap_ratio,
+        "blocking_room_id": rejection.blocking_room_id,
+    }
+
+
 def _projection_range(
     segment: WallSegment,
     axis: tuple[float, float],
@@ -329,3 +523,12 @@ def _dot(first: Iterable[float], second: Iterable[float]) -> float:
 
 def _xy(point: tuple[float, ...]) -> XY:
     return (float(point[0]), float(point[1]))
+
+
+def _midpoint(first: XY, second: XY) -> XY:
+    return ((first[0] + second[0]) / 2, (first[1] + second[1]) / 2)
+
+
+def _append_distinct(coords: list[XY], point: XY) -> None:
+    if coords[-1] != point:
+        coords.append(point)

--- a/python-code/src/floorplan_extractor/shared_walls.py
+++ b/python-code/src/floorplan_extractor/shared_walls.py
@@ -8,8 +8,6 @@ from math import atan2, cos, pi, radians, sin
 import geopandas as gpd
 from shapely.geometry import LineString, Point, Polygon
 
-from floorplan_extractor.dxf_polygon_extraction import SharedWallConfig
-
 XY = tuple[float, float]
 SegmentReplacement = tuple[XY, XY, XY, XY]
 MIN_SEGMENT_COORDINATES = 2
@@ -22,6 +20,39 @@ REVIEW_REJECTION_REASONS: frozenset[str] = frozenset(
         "third_room_intersection",
     }
 )
+
+
+@dataclass(frozen=True)
+class SharedWallConfig:
+    """
+    Configuration for optional shared-wall normalisation.
+
+    Attributes
+    ----------
+    enabled : bool
+        Whether shared-wall normalisation should run.
+    min_gap : float
+        Minimum distance between paired wall faces.
+    max_gap : float
+        Maximum distance between paired wall faces.
+    angle_tolerance_degrees : float
+        Maximum angle difference for wall faces to be considered parallel.
+    min_overlap_ratio : float
+        Minimum projected overlap ratio required for pairing.
+    min_overlap_length : float
+        Minimum projected overlap length required for pairing.
+    canonical_line : str
+        Strategy for choosing the replacement shared wall line.
+
+    """
+
+    enabled: bool = False
+    min_gap: float = 50.0
+    max_gap: float = 130.0
+    angle_tolerance_degrees: float = 2.0
+    min_overlap_ratio: float = 0.75
+    min_overlap_length: float = 250.0
+    canonical_line: str = "midline"
 
 
 @dataclass(frozen=True)

--- a/python-code/src/floorplan_extractor/shared_walls.py
+++ b/python-code/src/floorplan_extractor/shared_walls.py
@@ -16,9 +16,12 @@ from math import atan2, cos, pi, radians, sin
 import geopandas as gpd
 import shapely
 from shapely.geometry import LineString, Point, Polygon
+from shapely.geometry.base import BaseGeometry
+from shapely.strtree import STRtree
 
 XY = tuple[float, float]
 SegmentReplacement = tuple[float, XY, XY, XY, XY]
+SegmentPair = tuple["WallSegment", "WallSegment"]
 MIN_SEGMENT_COORDINATES = 2
 GEOMETRY_TOLERANCE = 1e-9
 COORDINATE_TOLERANCE = 1e-6
@@ -135,6 +138,15 @@ class SharedWallDetectionResult:
     rejections: list[SharedWallRejection]
 
 
+@dataclass(frozen=True)
+class _RoomSpatialIndex:
+    """Room geometries and their STRtree positions for obstruction checks."""
+
+    room_ids: list[Hashable]
+    geometries: list[BaseGeometry]
+    tree: STRtree
+
+
 def detect_shared_wall_candidates(
     rooms: gpd.GeoDataFrame,
     config: SharedWallConfig,
@@ -157,14 +169,45 @@ def detect_shared_wall_candidates(
 
     """
     segments = _extract_wall_segments(rooms)
+    pairs = _indexed_segment_pairs(segments, config.max_gap)
+    room_index = _build_room_spatial_index(rooms)
+    return _detect_shared_wall_candidates_from_pairs(
+        config,
+        pairs,
+        room_index,
+    )
+
+
+def _detect_shared_wall_candidates_exhaustive(
+    rooms: gpd.GeoDataFrame,
+    config: SharedWallConfig,
+) -> SharedWallDetectionResult:
+    """Return reference detection results using every cross-room segment pair."""
+    segments = _extract_wall_segments(rooms)
+    pairs = (
+        (first, second)
+        for first, second in combinations(segments, 2)
+        if first.room_id != second.room_id
+    )
+    room_index = _build_room_spatial_index(rooms)
+    return _detect_shared_wall_candidates_from_pairs(
+        config,
+        pairs,
+        room_index,
+    )
+
+
+def _detect_shared_wall_candidates_from_pairs(
+    config: SharedWallConfig,
+    pairs: Iterable[SegmentPair],
+    room_index: _RoomSpatialIndex,
+) -> SharedWallDetectionResult:
+    """Apply authoritative geometric checks to ordered segment pairs."""
     candidates: list[SharedWallCandidate] = []
     rejections: list[SharedWallRejection] = []
 
-    for first, second in combinations(segments, 2):
-        if first.room_id == second.room_id:
-            continue
-
-        candidate, rejection = _evaluate_pair(first, second, rooms, config)
+    for first, second in pairs:
+        candidate, rejection = _evaluate_pair(first, second, room_index, config)
         if candidate is not None:
             candidates.append(candidate)
         elif rejection is not None:
@@ -180,6 +223,54 @@ def detect_shared_wall_candidates(
     rejections.extend(ambiguity_rejections)
 
     return SharedWallDetectionResult(candidates=accepted, rejections=rejections)
+
+
+def _indexed_segment_pairs(
+    segments: list[WallSegment],
+    max_gap: float,
+) -> list[SegmentPair]:
+    """Return unique cross-room pairs selected by expanded segment envelopes."""
+    if not segments:
+        return []
+
+    expanded_envelopes = [
+        shapely.box(
+            segment.line.bounds[0] - max_gap,
+            segment.line.bounds[1] - max_gap,
+            segment.line.bounds[2] + max_gap,
+            segment.line.bounds[3] + max_gap,
+        )
+        for segment in segments
+    ]
+    tree = STRtree(expanded_envelopes)
+    pairs: list[SegmentPair] = []
+
+    for first_index, first in enumerate(segments):
+        matching_indices = sorted(
+            int(index) for index in tree.query(first.line.envelope)
+        )
+        for second_index in matching_indices:
+            if second_index <= first_index:
+                continue
+
+            second = segments[second_index]
+            if first.room_id == second.room_id:
+                continue
+
+            pairs.append((first, second))
+
+    return pairs
+
+
+def _build_room_spatial_index(rooms: gpd.GeoDataFrame) -> _RoomSpatialIndex:
+    """Build one ordered room index for exact third-room obstruction checks."""
+    room_ids = list(rooms.index)
+    geometries = list(rooms.geometry)
+    return _RoomSpatialIndex(
+        room_ids=room_ids,
+        geometries=geometries,
+        tree=STRtree(geometries),
+    )
 
 
 def normalise_shared_walls(
@@ -331,7 +422,7 @@ def _extract_wall_segments(rooms: gpd.GeoDataFrame) -> list[WallSegment]:
 def _evaluate_pair(
     first: WallSegment,
     second: WallSegment,
-    rooms: gpd.GeoDataFrame,
+    room_index: _RoomSpatialIndex,
     config: SharedWallConfig,
 ) -> tuple[SharedWallCandidate | None, SharedWallRejection | None]:
     if not _is_near_parallel(first, second, config.angle_tolerance_degrees):
@@ -367,7 +458,7 @@ def _evaluate_pair(
     return _evaluate_overlapping_pair(
         first,
         second,
-        rooms,
+        room_index,
         config,
         metrics,
     )
@@ -376,7 +467,7 @@ def _evaluate_pair(
 def _evaluate_overlapping_pair(
     first: WallSegment,
     second: WallSegment,
-    rooms: gpd.GeoDataFrame,
+    room_index: _RoomSpatialIndex,
     config: SharedWallConfig,
     metrics: SharedWallPairMetrics,
 ) -> tuple[SharedWallCandidate | None, SharedWallRejection | None]:
@@ -391,7 +482,11 @@ def _evaluate_overlapping_pair(
         )
 
     strip = _overlap_strip(first, second, metrics.overlap)
-    blocking_room_id = _blocking_room_id(rooms, strip, {first.room_id, second.room_id})
+    blocking_room_id = _blocking_room_id(
+        room_index,
+        strip,
+        {first.room_id, second.room_id},
+    )
     if blocking_room_id is not None:
         return None, SharedWallRejection(
             first,
@@ -468,17 +563,20 @@ def _overlap_strip(
 
 
 def _blocking_room_id(
-    rooms: gpd.GeoDataFrame,
+    room_index: _RoomSpatialIndex,
     strip: Polygon,
     paired_room_ids: set[Hashable],
 ) -> Hashable | None:
     if not strip.is_valid:
         strip = shapely.make_valid(strip)
 
-    for room_id, geometry in rooms.geometry.items():
+    matching_indices = sorted(int(index) for index in room_index.tree.query(strip))
+    for room_index_position in matching_indices:
+        room_id = room_index.room_ids[room_index_position]
         if room_id in paired_room_ids:
             continue
 
+        geometry = room_index.geometries[room_index_position]
         room_geometry = (
             shapely.make_valid(geometry) if not geometry.is_valid else geometry
         )

--- a/python-code/src/floorplan_extractor/shared_walls.py
+++ b/python-code/src/floorplan_extractor/shared_walls.py
@@ -1,4 +1,12 @@
-"""Candidate detection for shared wall-face normalisation."""
+"""
+Shared wall-face detection and normalisation.
+
+Architectural room polygons commonly follow opposite faces of the same
+physical wall. This module identifies compatible parallel overlaps and moves
+accepted pairs to one common midline. Rejected candidates are retained as
+diagnostic metadata so uncertain geometry can be reviewed without silently
+changing room boundaries.
+"""
 
 from collections.abc import Hashable, Iterable
 from dataclasses import dataclass
@@ -121,7 +129,7 @@ class SharedWallPairMetrics:
 
 @dataclass(frozen=True)
 class SharedWallDetectionResult:
-    """Candidate detection output for downstream diagnostics."""
+    """Accepted and rejected shared-wall records for downstream diagnostics."""
 
     candidates: list[SharedWallCandidate]
     rejections: list[SharedWallRejection]
@@ -195,7 +203,10 @@ def normalise_shared_walls(
     Returns
     -------
     geopandas.GeoDataFrame
-        A copy of ``rooms`` with updated geometries and shared-wall metadata.
+        A copy of ``rooms`` with updated geometries and the columns
+        ``shared_wall_count``, ``shared_wall_rejections``, and
+        ``shared_wall_review``. The complete detection result is also stored in
+        ``result.attrs["shared_wall_detection"]``.
 
     """
     result = rooms.copy()

--- a/python-code/src/floorplan_extractor/shared_walls.py
+++ b/python-code/src/floorplan_extractor/shared_walls.py
@@ -1,0 +1,331 @@
+"""Candidate detection for shared wall-face normalisation."""
+
+from collections.abc import Hashable, Iterable
+from dataclasses import dataclass
+from itertools import combinations, pairwise
+from math import atan2, cos, pi, radians, sin
+
+import geopandas as gpd
+from shapely.geometry import LineString, Polygon
+
+from floorplan_extractor.dxf_polygon_extraction import SharedWallConfig
+
+XY = tuple[float, float]
+MIN_SEGMENT_COORDINATES = 2
+GEOMETRY_TOLERANCE = 1e-9
+
+
+@dataclass(frozen=True)
+class WallSegment:
+    """A straight exterior segment from one room polygon."""
+
+    room_id: Hashable
+    segment_index: int
+    line: LineString
+    start: XY
+    end: XY
+    length: float
+    angle_radians: float
+
+    @property
+    def key(self) -> tuple[Hashable, int]:
+        """Return a stable key for matching and ambiguity checks."""
+        return (self.room_id, self.segment_index)
+
+
+@dataclass(frozen=True)
+class SharedWallCandidate:
+    """A candidate pair of wall faces that may represent one physical wall."""
+
+    first: WallSegment
+    second: WallSegment
+    gap: float
+    overlap_length: float
+    overlap_ratio: float
+    strip: Polygon
+
+
+@dataclass(frozen=True)
+class SharedWallRejection:
+    """A rejected wall-face pair with diagnostic context."""
+
+    first: WallSegment
+    second: WallSegment
+    reason: str
+    gap: float | None = None
+    overlap_length: float | None = None
+    overlap_ratio: float | None = None
+    blocking_room_id: Hashable | None = None
+
+
+@dataclass(frozen=True)
+class SharedWallDetectionResult:
+    """Candidate detection output for downstream diagnostics."""
+
+    candidates: list[SharedWallCandidate]
+    rejections: list[SharedWallRejection]
+
+
+def detect_shared_wall_candidates(
+    rooms: gpd.GeoDataFrame,
+    config: SharedWallConfig,
+) -> SharedWallDetectionResult:
+    """
+    Detect possible shared wall-face pairs without mutating room geometry.
+
+    Parameters
+    ----------
+    rooms : geopandas.GeoDataFrame
+        Room polygons to inspect. The GeoDataFrame index is used as the room
+        identifier in returned records.
+    config : SharedWallConfig
+        Geometric thresholds controlling candidate detection.
+
+    Returns
+    -------
+    SharedWallDetectionResult
+        Accepted candidates and rejected pair records.
+
+    """
+    segments = _extract_wall_segments(rooms)
+    candidates: list[SharedWallCandidate] = []
+    rejections: list[SharedWallRejection] = []
+
+    for first, second in combinations(segments, 2):
+        if first.room_id == second.room_id:
+            continue
+
+        candidate, rejection = _evaluate_pair(first, second, rooms, config)
+        if candidate is not None:
+            candidates.append(candidate)
+        elif rejection is not None:
+            rejections.append(rejection)
+
+    accepted, ambiguity_rejections = _reject_ambiguous_candidates(candidates)
+    rejections.extend(ambiguity_rejections)
+
+    return SharedWallDetectionResult(candidates=accepted, rejections=rejections)
+
+
+def _extract_wall_segments(rooms: gpd.GeoDataFrame) -> list[WallSegment]:
+    segments: list[WallSegment] = []
+
+    for room_id, geometry in rooms.geometry.items():
+        if not isinstance(geometry, Polygon) or geometry.is_empty:
+            continue
+
+        for segment_index, (start, end) in enumerate(
+            pairwise(geometry.exterior.coords)
+        ):
+            start_xy = _xy(start)
+            end_xy = _xy(end)
+            line = LineString([start_xy, end_xy])
+            if len(line.coords) < MIN_SEGMENT_COORDINATES:
+                continue
+            if line.length <= GEOMETRY_TOLERANCE:
+                continue
+
+            dx = end_xy[0] - start_xy[0]
+            dy = end_xy[1] - start_xy[1]
+            segments.append(
+                WallSegment(
+                    room_id=room_id,
+                    segment_index=segment_index,
+                    line=line,
+                    start=start_xy,
+                    end=end_xy,
+                    length=float(line.length),
+                    angle_radians=atan2(dy, dx) % pi,
+                )
+            )
+
+    return segments
+
+
+def _evaluate_pair(
+    first: WallSegment,
+    second: WallSegment,
+    rooms: gpd.GeoDataFrame,
+    config: SharedWallConfig,
+) -> tuple[SharedWallCandidate | None, SharedWallRejection | None]:
+    if not _is_near_parallel(first, second, config.angle_tolerance_degrees):
+        return None, None
+
+    gap = _perpendicular_gap(first, second)
+    if gap < config.min_gap or gap > config.max_gap:
+        return None, SharedWallRejection(first, second, "gap_out_of_range", gap=gap)
+
+    overlap = _projected_overlap(first, second)
+    overlap_length = overlap[1] - overlap[0]
+    overlap_ratio = overlap_length / min(first.length, second.length)
+    if overlap_length < config.min_overlap_length:
+        return None, SharedWallRejection(
+            first,
+            second,
+            "insufficient_overlap_length",
+            gap=gap,
+            overlap_length=overlap_length,
+            overlap_ratio=overlap_ratio,
+        )
+
+    if overlap_ratio < config.min_overlap_ratio:
+        return None, SharedWallRejection(
+            first,
+            second,
+            "insufficient_overlap_ratio",
+            gap=gap,
+            overlap_length=overlap_length,
+            overlap_ratio=overlap_ratio,
+        )
+
+    strip = _overlap_strip(first, second, overlap)
+    blocking_room_id = _blocking_room_id(rooms, strip, {first.room_id, second.room_id})
+    if blocking_room_id is not None:
+        return None, SharedWallRejection(
+            first,
+            second,
+            "third_room_intersection",
+            gap=gap,
+            overlap_length=overlap_length,
+            overlap_ratio=overlap_ratio,
+            blocking_room_id=blocking_room_id,
+        )
+
+    return (
+        SharedWallCandidate(
+            first=first,
+            second=second,
+            gap=gap,
+            overlap_length=overlap_length,
+            overlap_ratio=overlap_ratio,
+            strip=strip,
+        ),
+        None,
+    )
+
+
+def _is_near_parallel(
+    first: WallSegment,
+    second: WallSegment,
+    angle_tolerance_degrees: float,
+) -> bool:
+    angle_delta = abs(first.angle_radians - second.angle_radians)
+    angle_delta = min(angle_delta, pi - angle_delta)
+
+    return angle_delta <= radians(angle_tolerance_degrees)
+
+
+def _perpendicular_gap(first: WallSegment, second: WallSegment) -> float:
+    axis = _unit_axis(first)
+    normal = (-axis[1], axis[0])
+    offset = (second.start[0] - first.start[0], second.start[1] - first.start[1])
+
+    return abs(_dot(offset, normal))
+
+
+def _projected_overlap(first: WallSegment, second: WallSegment) -> tuple[float, float]:
+    axis = _unit_axis(first)
+    first_range = _projection_range(first, axis)
+    second_range = _projection_range(second, axis)
+
+    overlap_start = max(first_range[0], second_range[0])
+    overlap_end = min(first_range[1], second_range[1])
+
+    return (overlap_start, max(overlap_start, overlap_end))
+
+
+def _overlap_strip(
+    first: WallSegment,
+    second: WallSegment,
+    overlap: tuple[float, float],
+) -> Polygon:
+    first_start = _point_at_projection(first, overlap[0])
+    first_end = _point_at_projection(first, overlap[1])
+    second_start = _point_at_projection(second, overlap[0])
+    second_end = _point_at_projection(second, overlap[1])
+
+    return Polygon([first_start, first_end, second_end, second_start])
+
+
+def _blocking_room_id(
+    rooms: gpd.GeoDataFrame,
+    strip: Polygon,
+    paired_room_ids: set[Hashable],
+) -> Hashable | None:
+    for room_id, geometry in rooms.geometry.items():
+        if room_id in paired_room_ids:
+            continue
+
+        intersection = geometry.intersection(strip)
+        if intersection.area > GEOMETRY_TOLERANCE:
+            return room_id
+
+    return None
+
+
+def _reject_ambiguous_candidates(
+    candidates: list[SharedWallCandidate],
+) -> tuple[list[SharedWallCandidate], list[SharedWallRejection]]:
+    segment_counts: dict[tuple[Hashable, int], int] = {}
+    for candidate in candidates:
+        for key in (candidate.first.key, candidate.second.key):
+            segment_counts[key] = segment_counts.get(key, 0) + 1
+
+    accepted: list[SharedWallCandidate] = []
+    rejections: list[SharedWallRejection] = []
+
+    for candidate in candidates:
+        if (
+            segment_counts[candidate.first.key] == 1
+            and segment_counts[candidate.second.key] == 1
+        ):
+            accepted.append(candidate)
+            continue
+
+        rejections.append(
+            SharedWallRejection(
+                first=candidate.first,
+                second=candidate.second,
+                reason="ambiguous_match",
+                gap=candidate.gap,
+                overlap_length=candidate.overlap_length,
+                overlap_ratio=candidate.overlap_ratio,
+            )
+        )
+
+    return accepted, rejections
+
+
+def _projection_range(
+    segment: WallSegment,
+    axis: tuple[float, float],
+) -> tuple[float, float]:
+    projections = [_dot(point, axis) for point in (segment.start, segment.end)]
+
+    return (min(projections), max(projections))
+
+
+def _point_at_projection(segment: WallSegment, projection: float) -> XY:
+    axis = _unit_axis(segment)
+    origin_projection = _dot(segment.start, axis)
+    distance = projection - origin_projection
+
+    return (
+        segment.start[0] + axis[0] * distance,
+        segment.start[1] + axis[1] * distance,
+    )
+
+
+def _unit_axis(segment: WallSegment) -> tuple[float, float]:
+    return (cos(segment.angle_radians), sin(segment.angle_radians))
+
+
+def _dot(first: Iterable[float], second: Iterable[float]) -> float:
+    first_x, first_y = first
+    second_x, second_y = second
+
+    return (first_x * second_x) + (first_y * second_y)
+
+
+def _xy(point: tuple[float, ...]) -> XY:
+    return (float(point[0]), float(point[1]))

--- a/python-code/src/floorplan_extractor/yaml_construction.py
+++ b/python-code/src/floorplan_extractor/yaml_construction.py
@@ -8,7 +8,7 @@ focused on architectural topology rather than geospatial metadata.
 
 Responsibilities of this module include:
 - Converting polygon exteriors into ordered wall segments.
-- Mapping labelled polygons to room definitions.
+- Mapping labelled polygons and canonical door segments to room definitions.
 - Assembling building- and floor-level metadata into a serialisable form.
 - Writing the resulting structure to disk as YAML.
 
@@ -113,11 +113,15 @@ def polygons_to_rooms(
         GeoDataFrame containing polygon geometries.
     room_name_column : str
         Column containing room names.
+    door_column : str or None
+        Optional column containing lists of canonical door segments represented
+        as ``[x1, y1, x2, y2]``.
 
     Returns
     -------
     list[dict]
-        Room definitions suitable for YAML serialisation.
+        Room definitions containing ``name``, ``walls``, and ``doors`` values
+        suitable for YAML serialisation.
 
     """
     rooms = []

--- a/python-code/tests/__init__.py
+++ b/python-code/tests/__init__.py
@@ -1,0 +1,1 @@
+"""AMR Hub test suite."""

--- a/python-code/tests/floorplan_geometry_assertions.py
+++ b/python-code/tests/floorplan_geometry_assertions.py
@@ -1,0 +1,56 @@
+"""Deterministic assertions for local Cartesian floorplan geometry."""
+
+from collections.abc import Iterable
+
+import pytest
+import shapely
+from shapely.geometry.base import BaseGeometry
+
+FLOORPLAN_GEOMETRY_TOLERANCE = 1e-6
+
+
+def assert_geometry_equal(
+    actual: BaseGeometry,
+    expected: BaseGeometry,
+    *,
+    tolerance: float = FLOORPLAN_GEOMETRY_TOLERANCE,
+) -> None:
+    """
+    Assert geometries are structurally equal within a local-coordinate tolerance.
+
+    Shapely normalisation makes coordinate ordering deterministic before exact
+    comparison. The default tolerance is one millionth of a floorplan coordinate
+    unit, which absorbs floating-point projection noise without hiding material
+    geometry changes.
+
+    Parameters
+    ----------
+    actual : shapely.geometry.base.BaseGeometry
+        Geometry produced by the extraction pipeline.
+    expected : shapely.geometry.base.BaseGeometry
+        Regression baseline geometry.
+    tolerance : float
+        Maximum coordinate difference in local floorplan units.
+
+    """
+    if shapely.equals_exact(actual, expected, tolerance=tolerance, normalize=True):
+        return
+
+    pytest.fail(
+        "Geometry differs from regression baseline:\n"
+        f"actual={actual.wkt}\n"
+        f"expected={expected.wkt}\n"
+        f"tolerance={tolerance}"
+    )
+
+
+def rounded_optional(value: float | None, *, digits: int = 6) -> float | None:
+    """Round optional numeric diagnostic values for deterministic comparison."""
+    if isinstance(value, float):
+        return round(value, digits)
+    return value
+
+
+def sorted_records(records: Iterable[tuple[object, ...]]) -> list[tuple[object, ...]]:
+    """Return diagnostic tuples in deterministic string-key order."""
+    return sorted(records, key=repr)

--- a/python-code/tests/floorplan_regression_fixtures.py
+++ b/python-code/tests/floorplan_regression_fixtures.py
@@ -1,0 +1,303 @@
+"""Synthetic floorplan fixtures for geometry regression tests."""
+
+from collections.abc import Callable, Hashable
+from dataclasses import dataclass
+
+import geopandas as gpd
+from shapely.geometry import LineString, Polygon
+
+from floorplan_extractor.shared_walls import (
+    SharedWallCandidate,
+    SharedWallDetectionResult,
+    WallSegment,
+)
+
+CandidateRecord = tuple[
+    tuple[Hashable, int],
+    tuple[Hashable, int],
+    float,
+    float,
+    float,
+]
+RejectionRecord = tuple[
+    tuple[Hashable, int],
+    tuple[Hashable, int],
+    str,
+    float | None,
+    float | None,
+    float | None,
+    Hashable | None,
+]
+
+
+@dataclass(frozen=True)
+class FloorplanRegressionCase:
+    """One synthetic extraction scenario and its accepted baseline."""
+
+    name: str
+    rooms: gpd.GeoDataFrame
+    expected_geometry: tuple[Polygon, ...]
+    expected_candidates: tuple[CandidateRecord, ...]
+    expected_rejections: tuple[RejectionRecord, ...]
+    expected_counts: tuple[int, ...]
+    expected_review: tuple[bool, ...]
+    detection_factory: Callable[[], SharedWallDetectionResult] | None = None
+    doors: gpd.GeoDataFrame | None = None
+    expected_doors: tuple[tuple[tuple[float, float, float, float], ...], ...] | None = (
+        None
+    )
+    expected_door_report: tuple[tuple[str, int, bool], ...] | None = None
+
+
+def rectangle(min_x: float, min_y: float, max_x: float, max_y: float) -> Polygon:
+    """Create an axis-aligned synthetic room polygon."""
+    return Polygon(
+        [
+            (min_x, min_y),
+            (max_x, min_y),
+            (max_x, max_y),
+            (min_x, max_y),
+        ]
+    )
+
+
+def room_frame(*polygons: Polygon) -> gpd.GeoDataFrame:
+    """Create a room GeoDataFrame with stable integer identifiers."""
+    return gpd.GeoDataFrame({"geometry": list(polygons)}, geometry="geometry")
+
+
+def _valid_expected_geometry() -> tuple[Polygon, Polygon]:
+    return (
+        Polygon(
+            [
+                (0.0, 0.0),
+                (400.0, 0.0),
+                (450.0, 0.0),
+                (450.0, 400.0),
+                (400.0, 400.0),
+                (0.0, 400.0),
+            ]
+        ),
+        Polygon(
+            [
+                (500.0, 0.0),
+                (900.0, 0.0),
+                (900.0, 400.0),
+                (500.0, 400.0),
+                (450.0, 400.0),
+                (450.0, 0.0),
+            ]
+        ),
+    )
+
+
+def _invalid_normalisation_detection() -> SharedWallDetectionResult:
+    first = WallSegment(
+        room_id=0,
+        segment_index=2,
+        line=LineString([(1000.0, 100.0), (0.0, 100.0)]),
+        start=(1000.0, 100.0),
+        end=(0.0, 100.0),
+        length=1000.0,
+        angle_radians=0.0,
+    )
+    second = WallSegment(
+        room_id=1,
+        segment_index=2,
+        line=LineString([(1000.0, -100.0), (600.0, -100.0)]),
+        start=(1000.0, -100.0),
+        end=(600.0, -100.0),
+        length=400.0,
+        angle_radians=0.0,
+    )
+    candidate = SharedWallCandidate(
+        first=first,
+        second=second,
+        gap=200.0,
+        overlap_length=400.0,
+        overlap_ratio=1.0,
+        overlap=(600.0, 1000.0),
+        first_interval=(0.0, 400.0),
+        second_interval=(0.0, 400.0),
+        strip=Polygon(
+            [
+                (600.0, 100.0),
+                (1000.0, 100.0),
+                (1000.0, -100.0),
+                (600.0, -100.0),
+            ]
+        ),
+    )
+    return SharedWallDetectionResult(candidates=[candidate], rejections=[])
+
+
+def regression_cases() -> tuple[FloorplanRegressionCase, ...]:
+    """Return fresh synthetic cases covering accepted and rejected geometry."""
+    separated_geometry = (
+        rectangle(0.0, 0.0, 400.0, 400.0),
+        rectangle(1000.0, 1000.0, 1400.0, 1400.0),
+    )
+    valid_rooms = (
+        rectangle(0.0, 0.0, 400.0, 400.0),
+        rectangle(500.0, 0.0, 900.0, 400.0),
+    )
+    ambiguous_geometry = (
+        rectangle(0.0, 0.0, 400.0, 400.0),
+        rectangle(500.0, 0.0, 900.0, 400.0),
+        rectangle(500.0, 0.0, 900.0, 400.0),
+    )
+    obstruction_geometry = (
+        rectangle(0.0, 0.0, 400.0, 400.0),
+        rectangle(500.0, 0.0, 900.0, 400.0),
+        rectangle(425.0, 100.0, 475.0, 200.0),
+    )
+    invalid_geometry = (
+        rectangle(0.0, 0.0, 1000.0, 100.0),
+        rectangle(600.0, -200.0, 1000.0, -100.0),
+    )
+    canonical_door_source = gpd.GeoDataFrame(
+        {
+            "EntityHandle": ["door-1", "door-1", "door-1"],
+            "geometry": [
+                LineString([(450.0, 150.0), (550.0, 150.0)]),
+                LineString([(450.0, 250.0), (550.0, 250.0)]),
+                LineString([(550.0, 150.0), (500.0, 200.0), (450.0, 250.0)]),
+            ],
+        },
+        geometry="geometry",
+    )
+
+    valid_candidate: CandidateRecord = (
+        (0, 1),
+        (1, 3),
+        100.0,
+        400.0,
+        1.0,
+    )
+
+    return (
+        FloorplanRegressionCase(
+            name="separated_rooms",
+            rooms=room_frame(*separated_geometry),
+            expected_geometry=separated_geometry,
+            expected_candidates=(),
+            expected_rejections=(),
+            expected_counts=(0, 0),
+            expected_review=(False, False),
+        ),
+        FloorplanRegressionCase(
+            name="valid_shared_wall",
+            rooms=room_frame(*valid_rooms),
+            expected_geometry=_valid_expected_geometry(),
+            expected_candidates=(valid_candidate,),
+            expected_rejections=(),
+            expected_counts=(1, 1),
+            expected_review=(False, False),
+        ),
+        FloorplanRegressionCase(
+            name="ambiguous_one_to_many",
+            rooms=room_frame(*ambiguous_geometry),
+            expected_geometry=ambiguous_geometry,
+            expected_candidates=(),
+            expected_rejections=(
+                ((1, 0), (2, 0), "gap_too_small", 0.0, 400.0, 1.0, None),
+                ((1, 1), (2, 1), "gap_too_small", 0.0, 400.0, 1.0, None),
+                ((1, 2), (2, 2), "gap_too_small", 0.0, 400.0, 1.0, None),
+                ((1, 3), (2, 3), "gap_too_small", 0.0, 400.0, 1.0, None),
+                ((0, 1), (1, 3), "ambiguous_match", 100.0, 400.0, 1.0, None),
+                ((0, 1), (2, 3), "ambiguous_match", 100.0, 400.0, 1.0, None),
+            ),
+            expected_counts=(0, 0, 0),
+            expected_review=(True, True, True),
+        ),
+        FloorplanRegressionCase(
+            name="third_room_obstruction",
+            rooms=room_frame(*obstruction_geometry),
+            expected_geometry=obstruction_geometry,
+            expected_candidates=(),
+            expected_rejections=(
+                (
+                    (0, 1),
+                    (1, 3),
+                    "third_room_intersection",
+                    100.0,
+                    400.0,
+                    1.0,
+                    2,
+                ),
+                (
+                    (0, 1),
+                    (2, 1),
+                    "insufficient_overlap_length",
+                    75.0,
+                    100.0,
+                    1.0,
+                    None,
+                ),
+                (
+                    (0, 1),
+                    (2, 3),
+                    "gap_too_small",
+                    25.0,
+                    100.0,
+                    1.0,
+                    None,
+                ),
+                (
+                    (1, 3),
+                    (2, 1),
+                    "gap_too_small",
+                    25.0,
+                    100.0,
+                    1.0,
+                    None,
+                ),
+                (
+                    (1, 3),
+                    (2, 3),
+                    "insufficient_overlap_length",
+                    75.0,
+                    100.0,
+                    1.0,
+                    None,
+                ),
+            ),
+            expected_counts=(0, 0, 0),
+            expected_review=(True, True, True),
+        ),
+        FloorplanRegressionCase(
+            name="invalid_normalisation",
+            rooms=room_frame(*invalid_geometry),
+            expected_geometry=invalid_geometry,
+            expected_candidates=(),
+            expected_rejections=(
+                (
+                    (0, 2),
+                    (1, 2),
+                    "normalisation_invalid_geometry",
+                    200.0,
+                    400.0,
+                    1.0,
+                    None,
+                ),
+            ),
+            expected_counts=(0, 0),
+            expected_review=(True, True),
+            detection_factory=_invalid_normalisation_detection,
+        ),
+        FloorplanRegressionCase(
+            name="canonical_door_on_shared_boundary",
+            rooms=room_frame(*valid_rooms),
+            expected_geometry=_valid_expected_geometry(),
+            expected_candidates=(valid_candidate,),
+            expected_rejections=(),
+            expected_counts=(1, 1),
+            expected_review=(False, False),
+            doors=canonical_door_source,
+            expected_doors=(
+                ((450.0, 150.0, 450.0, 250.0),),
+                ((450.0, 150.0, 450.0, 250.0),),
+            ),
+            expected_door_report=(("door-1", 2, False),),
+        ),
+    )

--- a/python-code/tests/inputs/config.yaml
+++ b/python-code/tests/inputs/config.yaml
@@ -1,0 +1,26 @@
+polygons:
+  polygon_layer_name: "ROOM_BOUNDARIES"
+  label_layer_name: "ROOM_LABELS"
+  polygon_label_column: "label"
+  polygon_label_target: "room_number"
+  floor_filter: "TEST"
+  excluded_room_numbers:
+    - "TEST-001"
+    - "TEST-002"
+
+doors:
+  layer_name: "DOORS"
+  entity_col: "entity_id"
+  x_col: "x"
+  y_col: "y"
+  out_col: "doors"
+  predicate: "intersects"
+
+shared_walls:
+  enabled: true
+  min_gap: 50.0
+  max_gap: 130.0
+  angle_tolerance_degrees: 2.0
+  min_overlap_ratio: 0.75
+  min_overlap_length: 250.0
+  canonical_line: "midline"

--- a/python-code/tests/test_dxf_polygon_extraction.py
+++ b/python-code/tests/test_dxf_polygon_extraction.py
@@ -9,7 +9,6 @@ import pytest
 import yaml
 from shapely.geometry import LineString, Point, Polygon
 
-import floorplan_extractor.dxf_polygon_extraction as dxf_extraction
 from floorplan_extractor.dxf_polygon_extraction import (
     DoorAttachmentConfig,
     ExtractionConfig,

--- a/python-code/tests/test_dxf_polygon_extraction.py
+++ b/python-code/tests/test_dxf_polygon_extraction.py
@@ -367,7 +367,7 @@ def test_extract_polygons_applies_enabled_shared_wall_normalisation(
 ) -> None:
     """Enabled shared-wall normalisation runs before door attachment."""
     monkeypatch.setattr(
-        dxf_extraction.gpd,
+        gpd,
         "read_file",
         lambda _: _shared_wall_extraction_gdf(),
     )
@@ -400,7 +400,7 @@ def test_extract_polygons_preserves_shape_when_shared_walls_disabled(
 ) -> None:
     """Disabled shared-wall configuration leaves extraction output current-style."""
     monkeypatch.setattr(
-        dxf_extraction.gpd,
+        gpd,
         "read_file",
         lambda _: _shared_wall_extraction_gdf(),
     )
@@ -654,7 +654,7 @@ def test_extract_polygons_applies_merges_before_shared_walls(
 ) -> None:
     """Shared-wall normalisation receives the final merged room geometry."""
     monkeypatch.setattr(
-        dxf_extraction.gpd,
+        gpd,
         "read_file",
         lambda _: _shared_wall_extraction_gdf(),
     )
@@ -668,8 +668,7 @@ def test_extract_polygons_applies_merges_before_shared_walls(
         return rooms
 
     monkeypatch.setattr(
-        dxf_extraction,
-        "normalise_shared_walls",
+        "floorplan_extractor.dxf_polygon_extraction.normalise_shared_walls",
         record_shared_wall_input,
     )
     config = ExtractionConfig(

--- a/python-code/tests/test_dxf_polygon_extraction.py
+++ b/python-code/tests/test_dxf_polygon_extraction.py
@@ -13,11 +13,19 @@ import floorplan_extractor.dxf_polygon_extraction as dxf_extraction
 from floorplan_extractor.dxf_polygon_extraction import (
     DoorAttachmentConfig,
     ExtractionConfig,
+    PolygonAdditionConfig,
     PolygonExtractionConfig,
+    PolygonSplitConfig,
+    PolygonSplitRegionConfig,
     SharedWallConfig,
+    _apply_addition_labels,
+    _apply_polygon_additions,
+    _apply_polygon_splits,
+    _apply_split_region_labels,
     _attach_polygon_labels,
     _flatten_z_points,
     _generate_polygons,
+    _generate_room_numbers,
     config_from_yaml,
     extract_polygons,
 )
@@ -254,6 +262,61 @@ def test_config_from_yaml_loads_disabled_shared_wall_config(tmp_path: Path) -> N
     assert config.shared_walls.canonical_line == SHARED_WALL_CANONICAL_LINE
 
 
+def test_config_from_yaml_loads_polygon_splits(tmp_path: Path) -> None:
+    """Configured polygon cut lines and region labels are parsed."""
+    config_data = _base_config_data()
+    config_data["polygon_splits"] = [
+        {
+            "selector_point": [0.5, 0.5],
+            "cut_lines": [[1.0, -1.0, 1.0, 3.0]],
+            "regions": [
+                {"label": "101", "seed_point": [0.5, 0.5]},
+                {"label": "CORRIDOR", "seed_point": [1.5, 0.5]},
+            ],
+        }
+    ]
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config_data), encoding="utf-8")
+
+    config = config_from_yaml(config_path)
+
+    assert config.polygon_splits == [
+        PolygonSplitConfig(
+            selector_point=(0.5, 0.5),
+            cut_lines=[(1.0, -1.0, 1.0, 3.0)],
+            regions=[
+                PolygonSplitRegionConfig(label="101", seed_point=(0.5, 0.5)),
+                PolygonSplitRegionConfig(
+                    label="CORRIDOR",
+                    seed_point=(1.5, 0.5),
+                ),
+            ],
+        )
+    ]
+
+
+def test_config_from_yaml_loads_polygon_additions(tmp_path: Path) -> None:
+    """Explicit missing polygons and labels are parsed."""
+    config_data = _base_config_data()
+    config_data["polygon_additions"] = [
+        {
+            "label": "CORRIDOR",
+            "coordinates": POLYGON_COORDINATES,
+        }
+    ]
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config_data), encoding="utf-8")
+
+    config = config_from_yaml(config_path)
+
+    assert config.polygon_additions == [
+        PolygonAdditionConfig(
+            label="CORRIDOR",
+            coordinates=POLYGON_COORDINATES,
+        )
+    ]
+
+
 def test_config_from_yaml_rejects_invalid_shared_wall_canonical_line(
     tmp_path: Path,
 ) -> None:
@@ -368,6 +431,128 @@ def test_generate_polygons_from_linework() -> None:
 
     assert len(polygons) == 1
     assert isinstance(polygons.geometry.iloc[0], Polygon)
+
+
+def test_polygon_split_creates_and_labels_configured_regions() -> None:
+    """Configured cut lines create regions with explicit labels."""
+    polygons = gpd.GeoDataFrame(
+        {GEOMETRY_COLUMN: [Polygon(POLYGON_COORDINATES)]},
+        geometry=GEOMETRY_COLUMN,
+    )
+    split_config = PolygonSplitConfig(
+        selector_point=(0.5, 0.5),
+        cut_lines=[(1.0, -1.0, 1.0, 3.0)],
+        regions=[
+            PolygonSplitRegionConfig(label="101", seed_point=(0.5, 0.5)),
+            PolygonSplitRegionConfig(label="CORRIDOR", seed_point=(1.5, 0.5)),
+        ],
+    )
+
+    split_polygons = _apply_polygon_splits(polygons, [split_config])
+    labelled_polygons = split_polygons.assign(
+        **{
+            POLYGON_LABEL_TARGET: None,
+            "label_candidates": [[] for _ in range(len(split_polygons))],
+            "label_count": 0,
+            "label_ambiguous": False,
+        }
+    )
+    result = _apply_split_region_labels(
+        labelled_polygons,
+        [split_config],
+        POLYGON_LABEL_TARGET,
+    )
+
+    assert len(result) == 2
+    assert set(result[POLYGON_LABEL_TARGET]) == {"101", "CORRIDOR"}
+    assert result["label_count"].to_list() == [1, 1]
+    assert result["label_ambiguous"].to_list() == [False, False]
+
+
+def test_polygon_addition_creates_and_labels_missing_region() -> None:
+    """Configured additions create explicitly labelled polygons."""
+    polygons = gpd.GeoDataFrame(
+        {GEOMETRY_COLUMN: []},
+        geometry=GEOMETRY_COLUMN,
+    )
+    addition_config = PolygonAdditionConfig(
+        label="CORRIDOR",
+        coordinates=POLYGON_COORDINATES,
+    )
+
+    added_polygons = _apply_polygon_additions(polygons, [addition_config])
+    labelled_polygons = added_polygons.assign(
+        **{
+            POLYGON_LABEL_TARGET: None,
+            "label_candidates": [[]],
+            "label_count": 0,
+            "label_ambiguous": False,
+        }
+    )
+    result = _apply_addition_labels(
+        labelled_polygons,
+        [addition_config],
+        POLYGON_LABEL_TARGET,
+    )
+
+    assert len(result) == 1
+    assert result.loc[0, POLYGON_LABEL_TARGET] == "CORRIDOR"
+    assert result.loc[0, "label_candidates"] == ["CORRIDOR"]
+    assert result.loc[0, "label_count"] == 1
+    assert not result.loc[0, "label_ambiguous"]
+
+
+def test_generate_room_numbers_extracts_codes_from_multiline_labels() -> None:
+    """Room codes are extracted regardless of their line within label text."""
+    gdf = gpd.GeoDataFrame(
+        {
+            LAYER_COLUMN: [LABEL_LAYER_NAME] * 3,
+            POLYGON_LABEL_COLUMN: [
+                "STORE\n101",
+                "102\nLINEN",
+                "OTHER FLOOR\n201",
+            ],
+            GEOMETRY_COLUMN: [
+                Point(0.0, 0.0),
+                Point(1.0, 1.0),
+                Point(2.0, 2.0),
+            ],
+        },
+        geometry=GEOMETRY_COLUMN,
+    )
+
+    result = _generate_room_numbers(
+        gdf,
+        label_layer_name=LABEL_LAYER_NAME,
+        floor_filter=FLOOR_FILTER,
+        polygon_label_column=POLYGON_LABEL_COLUMN,
+        excluded_room_numbers=[],
+    )
+
+    assert result[POLYGON_LABEL_COLUMN].to_list() == ["101", "102"]
+
+
+def test_generate_room_numbers_excludes_normalised_multiline_codes() -> None:
+    """Exclusions apply after a room code is extracted from multiline text."""
+    excluded_label = "101"
+    gdf = gpd.GeoDataFrame(
+        {
+            LAYER_COLUMN: [LABEL_LAYER_NAME],
+            POLYGON_LABEL_COLUMN: [f"STORE\n{excluded_label}"],
+            GEOMETRY_COLUMN: [Point(0.0, 0.0)],
+        },
+        geometry=GEOMETRY_COLUMN,
+    )
+
+    result = _generate_room_numbers(
+        gdf,
+        label_layer_name=LABEL_LAYER_NAME,
+        floor_filter=FLOOR_FILTER,
+        polygon_label_column=POLYGON_LABEL_COLUMN,
+        excluded_room_numbers=[excluded_label],
+    )
+
+    assert result.empty
 
 
 def test_attach_polygon_labels_selects_primary_label_and_records_ambiguity() -> None:

--- a/python-code/tests/test_dxf_polygon_extraction.py
+++ b/python-code/tests/test_dxf_polygon_extraction.py
@@ -28,6 +28,7 @@ from floorplan_extractor.dxf_polygon_extraction import (
     _flatten_z_points,
     _generate_polygons,
     _generate_room_numbers,
+    attach_room_doors,
     config_from_yaml,
     extract_polygons,
 )
@@ -423,6 +424,40 @@ def test_extract_polygons_preserves_shape_when_shared_walls_disabled(
     assert "shared_wall_review" not in result.columns
     assert "shared_wall_rejections" not in result.columns
     assert result["door_count"].to_list() == [0, 0]
+
+
+def test_attach_room_doors_projects_door_symbol_onto_shared_wall() -> None:
+    """Door symbols become one canonical segment on the shared wall."""
+    rooms = gpd.GeoDataFrame(
+        {
+            GEOMETRY_COLUMN: [
+                Polygon([(0.0, 0.0), (5.0, 0.0), (5.0, 10.0), (0.0, 10.0)]),
+                Polygon([(5.0, 0.0), (10.0, 0.0), (10.0, 10.0), (5.0, 10.0)]),
+            ]
+        },
+        geometry=GEOMETRY_COLUMN,
+    )
+    doors = gpd.GeoDataFrame(
+        {
+            "EntityHandle": [DOOR_ENTITY_HANDLE] * 3,
+            GEOMETRY_COLUMN: [
+                LineString([(5.0, 4.0), (8.0, 4.0)]),
+                LineString([(5.0, 6.0), (8.0, 6.0)]),
+                LineString([(8.0, 4.0), (7.0, 5.5), (5.0, 6.0)]),
+            ],
+        },
+        geometry=GEOMETRY_COLUMN,
+    )
+
+    result = attach_room_doors(rooms, doors)
+
+    expected_door = [5.0, 4.0, 5.0, 6.0]
+    assert result["doors"].to_list() == [[expected_door], [expected_door]]
+    for room_id, door_values in result["doors"].items():
+        door_line = LineString(
+            [(door_values[0][0], door_values[0][1]), door_values[0][2:]]
+        )
+        assert door_line.difference(result.geometry.iloc[room_id].boundary).is_empty
 
 
 def test_flatten_z_points_removes_z_dimension() -> None:

--- a/python-code/tests/test_dxf_polygon_extraction.py
+++ b/python-code/tests/test_dxf_polygon_extraction.py
@@ -1,5 +1,6 @@
 """Module for testing extraction of polygons from dxf linework."""
 
+from itertools import pairwise
 from pathlib import Path
 from typing import Any
 
@@ -8,7 +9,9 @@ import pytest
 import yaml
 from shapely.geometry import LineString, Point, Polygon
 
+import floorplan_extractor.dxf_polygon_extraction as dxf_extraction
 from floorplan_extractor.dxf_polygon_extraction import (
+    DoorAttachmentConfig,
     ExtractionConfig,
     PolygonExtractionConfig,
     SharedWallConfig,
@@ -16,6 +19,7 @@ from floorplan_extractor.dxf_polygon_extraction import (
     _flatten_z_points,
     _generate_polygons,
     config_from_yaml,
+    extract_polygons,
 )
 
 # Constants
@@ -56,6 +60,102 @@ SHARED_WALL_ANGLE_TOLERANCE_DEGREES: float = 2.0
 SHARED_WALL_MIN_OVERLAP_RATIO: float = 0.75
 SHARED_WALL_MIN_OVERLAP_LENGTH: float = 250.0
 SHARED_WALL_CANONICAL_LINE: str = "midline"
+DOOR_LAYER_NAME: str = "DOORS"
+DOOR_ENTITY_HANDLE: str = "door-1"
+
+
+def _polygon_config() -> PolygonExtractionConfig:
+    return PolygonExtractionConfig(
+        polygon_layer_name=POLYGON_LAYER_NAME,
+        label_layer_name=LABEL_LAYER_NAME,
+        polygon_label_column=POLYGON_LABEL_COLUMN,
+        polygon_label_target=POLYGON_LABEL_TARGET,
+        floor_filter=FLOOR_FILTER,
+        excluded_room_numbers=[],
+    )
+
+
+def _shared_wall_config(*, enabled: bool) -> SharedWallConfig:
+    return SharedWallConfig(
+        enabled=enabled,
+        min_gap=SHARED_WALL_MIN_GAP,
+        max_gap=SHARED_WALL_MAX_GAP,
+        angle_tolerance_degrees=SHARED_WALL_ANGLE_TOLERANCE_DEGREES,
+        min_overlap_ratio=SHARED_WALL_MIN_OVERLAP_RATIO,
+        min_overlap_length=SHARED_WALL_MIN_OVERLAP_LENGTH,
+        canonical_line=SHARED_WALL_CANONICAL_LINE,
+    )
+
+
+def _rectangle_lines(
+    min_x: float,
+    min_y: float,
+    max_x: float,
+    max_y: float,
+) -> list[LineString]:
+    return [
+        LineString([(min_x, min_y), (max_x, min_y)]),
+        LineString([(max_x, min_y), (max_x, max_y)]),
+        LineString([(max_x, max_y), (min_x, max_y)]),
+        LineString([(min_x, max_y), (min_x, min_y)]),
+    ]
+
+
+def _shared_wall_extraction_gdf() -> gpd.GeoDataFrame:
+    room_boundary_lines = [
+        *_rectangle_lines(0.0, 0.0, 400.0, 400.0),
+        *_rectangle_lines(500.0, 0.0, 900.0, 400.0),
+    ]
+    rows: list[dict[str, object]] = [
+        {
+            LAYER_COLUMN: POLYGON_LAYER_NAME,
+            "EntityHandle": None,
+            POLYGON_LABEL_COLUMN: None,
+            GEOMETRY_COLUMN: line,
+        }
+        for line in room_boundary_lines
+    ]
+
+    rows.extend(
+        [
+            {
+                LAYER_COLUMN: LABEL_LAYER_NAME,
+                "EntityHandle": None,
+                POLYGON_LABEL_COLUMN: "101",
+                GEOMETRY_COLUMN: Point(200.0, 200.0),
+            },
+            {
+                LAYER_COLUMN: LABEL_LAYER_NAME,
+                "EntityHandle": None,
+                POLYGON_LABEL_COLUMN: "102",
+                GEOMETRY_COLUMN: Point(700.0, 200.0),
+            },
+            {
+                LAYER_COLUMN: DOOR_LAYER_NAME,
+                "EntityHandle": DOOR_ENTITY_HANDLE,
+                POLYGON_LABEL_COLUMN: None,
+                GEOMETRY_COLUMN: LineString([(450.0, 150.0), (450.0, 250.0)]),
+            },
+        ]
+    )
+
+    return gpd.GeoDataFrame(rows, geometry=GEOMETRY_COLUMN)
+
+
+def _canonical_segments(polygon: Polygon) -> set[tuple[tuple[float, float], ...]]:
+    coords = list(polygon.exterior.coords)
+
+    return {
+        tuple(
+            sorted(
+                (
+                    (round(start[0], 6), round(start[1], 6)),
+                    (round(end[0], 6), round(end[1], 6)),
+                )
+            )
+        )
+        for start, end in pairwise(coords)
+    }
 
 
 def _base_config_data() -> dict[str, Any]:
@@ -172,6 +272,70 @@ def test_config_from_yaml_rejects_invalid_shared_wall_canonical_line(
         match=r"'shared_walls\.canonical_line' must be one of midline",
     ):
         config_from_yaml(config_path)
+
+
+def test_extract_polygons_applies_enabled_shared_wall_normalisation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Enabled shared-wall normalisation runs before door attachment."""
+    monkeypatch.setattr(
+        dxf_extraction.gpd,
+        "read_file",
+        lambda _: _shared_wall_extraction_gdf(),
+    )
+    config = ExtractionConfig(
+        polygons=_polygon_config(),
+        door_layer_name=DOOR_LAYER_NAME,
+        doors=DoorAttachmentConfig(),
+        shared_walls=_shared_wall_config(enabled=True),
+    )
+
+    result = extract_polygons(tmp_path / "floorplan.dxf", config)
+
+    expected_midline = ((450.0, 0.0), (450.0, 400.0))
+    assert tuple(sorted(expected_midline)) in _canonical_segments(
+        result.geometry.iloc[0]
+    )
+    assert tuple(sorted(expected_midline)) in _canonical_segments(
+        result.geometry.iloc[1]
+    )
+    assert result["shared_wall_count"].to_list() == [1, 1]
+    assert result["shared_wall_review"].to_list() == [False, False]
+    assert result["door_count"].to_list() == [1, 1]
+    assert result["doors"].apply(bool).to_list() == [True, True]
+    assert result["needs_review"].to_list() == [False, False]
+
+
+def test_extract_polygons_preserves_shape_when_shared_walls_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Disabled shared-wall configuration leaves extraction output current-style."""
+    monkeypatch.setattr(
+        dxf_extraction.gpd,
+        "read_file",
+        lambda _: _shared_wall_extraction_gdf(),
+    )
+    config = ExtractionConfig(
+        polygons=_polygon_config(),
+        door_layer_name=DOOR_LAYER_NAME,
+        doors=DoorAttachmentConfig(),
+        shared_walls=_shared_wall_config(enabled=False),
+    )
+
+    result = extract_polygons(tmp_path / "floorplan.dxf", config)
+
+    assert tuple(sorted(((400.0, 0.0), (400.0, 400.0)))) in _canonical_segments(
+        result.geometry.iloc[0]
+    )
+    assert tuple(sorted(((500.0, 0.0), (500.0, 400.0)))) in _canonical_segments(
+        result.geometry.iloc[1]
+    )
+    assert "shared_wall_count" not in result.columns
+    assert "shared_wall_review" not in result.columns
+    assert "shared_wall_rejections" not in result.columns
+    assert result["door_count"].to_list() == [0, 0]
 
 
 def test_flatten_z_points_removes_z_dimension() -> None:

--- a/python-code/tests/test_dxf_polygon_extraction.py
+++ b/python-code/tests/test_dxf_polygon_extraction.py
@@ -225,9 +225,9 @@ def test_config_from_yaml_loads_shared_wall_config(tmp_path: Path) -> None:
     assert config.shared_walls.canonical_line == SHARED_WALL_CANONICAL_LINE
 
 
-def test_example_config_loads_shared_wall_config() -> None:
-    """The example extraction configuration includes shared-wall settings."""
-    config_path = Path(__file__).parents[1] / "config.yaml"
+def test_mock_config_loads_shared_wall_config() -> None:
+    """The mock extraction configuration includes shared-wall settings."""
+    config_path = Path(__file__).parent / "inputs" / "config.yaml"
 
     config = config_from_yaml(config_path)
 

--- a/python-code/tests/test_dxf_polygon_extraction.py
+++ b/python-code/tests/test_dxf_polygon_extraction.py
@@ -15,11 +15,13 @@ from floorplan_extractor.dxf_polygon_extraction import (
     ExtractionConfig,
     PolygonAdditionConfig,
     PolygonExtractionConfig,
+    PolygonMergeConfig,
     PolygonSplitConfig,
     PolygonSplitRegionConfig,
     SharedWallConfig,
     _apply_addition_labels,
     _apply_polygon_additions,
+    _apply_polygon_merges,
     _apply_polygon_splits,
     _apply_split_region_labels,
     _attach_polygon_labels,
@@ -317,6 +319,28 @@ def test_config_from_yaml_loads_polygon_additions(tmp_path: Path) -> None:
     ]
 
 
+def test_config_from_yaml_loads_polygon_merges(tmp_path: Path) -> None:
+    """Configured source labels and target label are parsed."""
+    config_data = _base_config_data()
+    config_data["polygon_merges"] = [
+        {
+            "target_label": "101",
+            "source_labels": ["CORRIDOR"],
+        }
+    ]
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config_data), encoding="utf-8")
+
+    config = config_from_yaml(config_path)
+
+    assert config.polygon_merges == [
+        PolygonMergeConfig(
+            target_label="101",
+            source_labels=["CORRIDOR"],
+        )
+    ]
+
+
 def test_config_from_yaml_rejects_invalid_shared_wall_canonical_line(
     tmp_path: Path,
 ) -> None:
@@ -500,6 +524,151 @@ def test_polygon_addition_creates_and_labels_missing_region() -> None:
     assert result.loc[0, "label_candidates"] == ["CORRIDOR"]
     assert result.loc[0, "label_count"] == 1
     assert not result.loc[0, "label_ambiguous"]
+
+
+def test_polygon_merge_combines_multiple_source_polygons() -> None:
+    """All matching source polygons are absorbed into the target polygon."""
+    polygons = gpd.GeoDataFrame(
+        {
+            POLYGON_LABEL_TARGET: ["101", "CORRIDOR", "CORRIDOR"],
+            "label_candidates": [["101"], ["CORRIDOR"], ["CORRIDOR"]],
+            "label_count": [1, 1, 1],
+            "label_ambiguous": [False, False, False],
+            GEOMETRY_COLUMN: [
+                Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                Polygon([(1, 0), (2, 0), (2, 1), (1, 1)]),
+                Polygon([(2, 0), (3, 0), (3, 1), (2, 1)]),
+            ],
+        },
+        geometry=GEOMETRY_COLUMN,
+    )
+
+    result = _apply_polygon_merges(
+        polygons,
+        [PolygonMergeConfig(target_label="101", source_labels=["CORRIDOR"])],
+        POLYGON_LABEL_TARGET,
+    )
+
+    assert len(result) == 1
+    assert result.loc[0, POLYGON_LABEL_TARGET] == "101"
+    assert result.loc[0, "label_candidates"] == ["101"]
+    assert result.loc[0, "label_count"] == 1
+    assert not result.loc[0, "label_ambiguous"]
+    assert result.geometry.iloc[0].area == pytest.approx(3.0)
+
+
+@pytest.mark.parametrize(
+    ("labels", "geometries", "expected_message"),
+    [
+        (
+            ["CORRIDOR"],
+            [Polygon([(1, 0), (2, 0), (2, 1), (1, 1)])],
+            "target must identify exactly one polygon",
+        ),
+        (
+            ["101", "101", "CORRIDOR"],
+            [
+                Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                Polygon([(0, 1), (1, 1), (1, 2), (0, 2)]),
+                Polygon([(1, 0), (2, 0), (2, 1), (1, 1)]),
+            ],
+            "target must identify exactly one polygon",
+        ),
+        (
+            ["101"],
+            [Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
+            "source must identify at least one polygon",
+        ),
+        (
+            ["101", "CORRIDOR"],
+            [
+                Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                Polygon([(2, 0), (3, 0), (3, 1), (2, 1)]),
+            ],
+            "must produce one valid Polygon",
+        ),
+    ],
+)
+def test_polygon_merge_rejects_invalid_selection_or_geometry(
+    labels: list[str],
+    geometries: list[Polygon],
+    expected_message: str,
+) -> None:
+    """Invalid or disconnected merge selections fail rather than losing geometry."""
+    polygons = gpd.GeoDataFrame(
+        {
+            POLYGON_LABEL_TARGET: labels,
+            "label_candidates": [[label] for label in labels],
+            "label_count": [1] * len(labels),
+            "label_ambiguous": [False] * len(labels),
+            GEOMETRY_COLUMN: geometries,
+        },
+        geometry=GEOMETRY_COLUMN,
+    )
+
+    with pytest.raises(ValueError, match=expected_message):
+        _apply_polygon_merges(
+            polygons,
+            [PolygonMergeConfig(target_label="101", source_labels=["CORRIDOR"])],
+            POLYGON_LABEL_TARGET,
+        )
+
+
+def test_extract_polygons_applies_merges_before_shared_walls(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Shared-wall normalisation receives the final merged room geometry."""
+    monkeypatch.setattr(
+        dxf_extraction.gpd,
+        "read_file",
+        lambda _: _shared_wall_extraction_gdf(),
+    )
+    observed_labels: list[str] = []
+
+    def record_shared_wall_input(
+        rooms: gpd.GeoDataFrame,
+        _config: SharedWallConfig,
+    ) -> gpd.GeoDataFrame:
+        observed_labels.extend(rooms[POLYGON_LABEL_TARGET].to_list())
+        return rooms
+
+    monkeypatch.setattr(
+        dxf_extraction,
+        "normalise_shared_walls",
+        record_shared_wall_input,
+    )
+    config = ExtractionConfig(
+        polygons=_polygon_config(),
+        shared_walls=_shared_wall_config(enabled=True),
+        polygon_additions=[
+            PolygonAdditionConfig(
+                label="CORRIDOR",
+                coordinates=[
+                    (400.0, 0.0),
+                    (500.0, 0.0),
+                    (500.0, 400.0),
+                    (400.0, 400.0),
+                ],
+            )
+        ],
+        polygon_merges=[
+            PolygonMergeConfig(
+                target_label="101",
+                source_labels=["CORRIDOR"],
+            )
+        ],
+    )
+
+    result = extract_polygons(tmp_path / "floorplan.dxf", config)
+
+    assert observed_labels == ["101", "102"]
+    assert result[POLYGON_LABEL_TARGET].to_list() == ["101", "102"]
+    target_geometry = result.loc[
+        result[POLYGON_LABEL_TARGET] == "101",
+        "geometry",
+    ].iloc[0]
+    assert target_geometry.area == pytest.approx(200000.0)
 
 
 def test_generate_room_numbers_extracts_codes_from_multiline_labels() -> None:

--- a/python-code/tests/test_dxf_polygon_extraction.py
+++ b/python-code/tests/test_dxf_polygon_extraction.py
@@ -4,12 +4,14 @@ from pathlib import Path
 from typing import Any
 
 import geopandas as gpd
+import pytest
 import yaml
 from shapely.geometry import LineString, Point, Polygon
 
 from floorplan_extractor.dxf_polygon_extraction import (
     ExtractionConfig,
     PolygonExtractionConfig,
+    SharedWallConfig,
     _attach_polygon_labels,
     _flatten_z_points,
     _generate_polygons,
@@ -48,11 +50,16 @@ EXPECTED_AGGREGATED_LABEL: str = "101, 102"
 Z_POINT_X: float = 1.0
 Z_POINT_Y: float = 2.0
 Z_POINT_Z: float = 3.0
+SHARED_WALL_MIN_GAP: float = 50.0
+SHARED_WALL_MAX_GAP: float = 130.0
+SHARED_WALL_ANGLE_TOLERANCE_DEGREES: float = 2.0
+SHARED_WALL_MIN_OVERLAP_RATIO: float = 0.75
+SHARED_WALL_MIN_OVERLAP_LENGTH: float = 250.0
+SHARED_WALL_CANONICAL_LINE: str = "midline"
 
 
-def test_config_from_yaml(tmp_path: Path) -> None:
-    """YAML configuration is loaded into an ExtractionConfig."""
-    config_data: dict[str, Any] = {
+def _base_config_data() -> dict[str, Any]:
+    return {
         "polygons": {
             "polygon_layer_name": POLYGON_LAYER_NAME,
             "label_layer_name": LABEL_LAYER_NAME,
@@ -62,6 +69,11 @@ def test_config_from_yaml(tmp_path: Path) -> None:
             "excluded_room_numbers": [],
         }
     }
+
+
+def test_config_from_yaml(tmp_path: Path) -> None:
+    """YAML configuration is loaded into an ExtractionConfig."""
+    config_data = _base_config_data()
 
     config_path: Path = tmp_path / "config.yaml"
     config_path.write_text(yaml.safe_dump(config_data), encoding="utf-8")
@@ -79,6 +91,87 @@ def test_config_from_yaml(tmp_path: Path) -> None:
 
     assert config.door_layer_name is None
     assert config.doors is None
+    assert config.shared_walls is None
+
+
+def test_config_from_yaml_loads_shared_wall_config(tmp_path: Path) -> None:
+    """Shared-wall configuration is parsed when present."""
+    config_data = _base_config_data()
+    config_data["shared_walls"] = {
+        "enabled": True,
+        "min_gap": SHARED_WALL_MIN_GAP,
+        "max_gap": SHARED_WALL_MAX_GAP,
+        "angle_tolerance_degrees": SHARED_WALL_ANGLE_TOLERANCE_DEGREES,
+        "min_overlap_ratio": SHARED_WALL_MIN_OVERLAP_RATIO,
+        "min_overlap_length": SHARED_WALL_MIN_OVERLAP_LENGTH,
+        "canonical_line": SHARED_WALL_CANONICAL_LINE,
+    }
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config_data), encoding="utf-8")
+
+    config = config_from_yaml(config_path)
+
+    assert isinstance(config.shared_walls, SharedWallConfig)
+    assert config.shared_walls.enabled is True
+    assert config.shared_walls.min_gap == SHARED_WALL_MIN_GAP
+    assert config.shared_walls.max_gap == SHARED_WALL_MAX_GAP
+    assert (
+        config.shared_walls.angle_tolerance_degrees
+        == SHARED_WALL_ANGLE_TOLERANCE_DEGREES
+    )
+    assert config.shared_walls.min_overlap_ratio == SHARED_WALL_MIN_OVERLAP_RATIO
+    assert config.shared_walls.min_overlap_length == SHARED_WALL_MIN_OVERLAP_LENGTH
+    assert config.shared_walls.canonical_line == SHARED_WALL_CANONICAL_LINE
+
+
+def test_example_config_loads_shared_wall_config() -> None:
+    """The example extraction configuration includes shared-wall settings."""
+    config_path = Path(__file__).parents[1] / "config.yaml"
+
+    config = config_from_yaml(config_path)
+
+    assert isinstance(config.shared_walls, SharedWallConfig)
+    assert config.shared_walls.enabled is True
+    assert config.shared_walls.canonical_line == SHARED_WALL_CANONICAL_LINE
+
+
+def test_config_from_yaml_loads_disabled_shared_wall_config(tmp_path: Path) -> None:
+    """Disabled shared-wall configuration is parsed without enabling behaviour."""
+    config_data = _base_config_data()
+    config_data["shared_walls"] = {
+        "enabled": False,
+        "canonical_line": SHARED_WALL_CANONICAL_LINE,
+    }
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config_data), encoding="utf-8")
+
+    config = config_from_yaml(config_path)
+
+    assert isinstance(config.shared_walls, SharedWallConfig)
+    assert config.shared_walls.enabled is False
+    assert config.shared_walls.canonical_line == SHARED_WALL_CANONICAL_LINE
+
+
+def test_config_from_yaml_rejects_invalid_shared_wall_canonical_line(
+    tmp_path: Path,
+) -> None:
+    """Invalid shared-wall canonical line values fail with a clear error."""
+    config_data = _base_config_data()
+    config_data["shared_walls"] = {
+        "enabled": True,
+        "canonical_line": "left-face",
+    }
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config_data), encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match=r"'shared_walls\.canonical_line' must be one of midline",
+    ):
+        config_from_yaml(config_path)
 
 
 def test_flatten_z_points_removes_z_dimension() -> None:

--- a/python-code/tests/test_dxf_polygon_extraction.py
+++ b/python-code/tests/test_dxf_polygon_extraction.py
@@ -49,7 +49,7 @@ POLYGON_COORDINATES: list[tuple[float, float]] = [
 ]
 
 LABEL_VALUES: list[str] = ["101", "102"]
-EXPECTED_AGGREGATED_LABEL: str = "101, 102"
+EXPECTED_PRIMARY_LABEL: str = "101"
 
 Z_POINT_X: float = 1.0
 Z_POINT_Y: float = 2.0
@@ -370,8 +370,8 @@ def test_generate_polygons_from_linework() -> None:
     assert isinstance(polygons.geometry.iloc[0], Polygon)
 
 
-def test_attach_polygon_labels_aggregates_sorted_labels() -> None:
-    """Multiple labels within a polygon are aggregated deterministically."""
+def test_attach_polygon_labels_selects_primary_label_and_records_ambiguity() -> None:
+    """Multiple labels produce one primary label and ambiguity diagnostics."""
     polygons: gpd.GeoDataFrame = gpd.GeoDataFrame(
         {GEOMETRY_COLUMN: [Polygon(POLYGON_COORDINATES)]},
         geometry=GEOMETRY_COLUMN,
@@ -395,5 +395,8 @@ def test_attach_polygon_labels_aggregates_sorted_labels() -> None:
         polygon_label_target=POLYGON_LABEL_TARGET,
     )
 
-    assert result.loc[0, POLYGON_LABEL_TARGET] == EXPECTED_AGGREGATED_LABEL
+    assert result.loc[0, POLYGON_LABEL_TARGET] == EXPECTED_PRIMARY_LABEL
+    assert result.loc[0, "label_candidates"] == LABEL_VALUES
+    assert result.loc[0, "label_count"] == len(LABEL_VALUES)
+    assert result.loc[0, "label_ambiguous"]
     assert result.loc[0, GEOMETRY_TYPE_COLUMN] == "POLYGON"

--- a/python-code/tests/test_floorplan_regression.py
+++ b/python-code/tests/test_floorplan_regression.py
@@ -1,0 +1,150 @@
+"""Regression baseline for floorplan geometry and diagnostics."""
+
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+
+from floorplan_extractor.dxf_polygon_extraction import attach_room_doors
+from floorplan_extractor.shared_walls import (
+    SharedWallCandidate,
+    SharedWallConfig,
+    SharedWallRejection,
+    detect_shared_wall_candidates,
+    normalise_shared_walls,
+)
+from tests.floorplan_geometry_assertions import (
+    assert_geometry_equal,
+    rounded_optional,
+    sorted_records,
+)
+from tests.floorplan_regression_fixtures import (
+    CandidateRecord,
+    FloorplanRegressionCase,
+    RejectionRecord,
+    regression_cases,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Hashable
+
+MIN_GAP = 50.0
+MAX_GAP = 130.0
+MIN_OVERLAP_LENGTH = 250.0
+MIN_OVERLAP_RATIO = 0.75
+
+
+def _config() -> SharedWallConfig:
+    return SharedWallConfig(
+        enabled=True,
+        min_gap=MIN_GAP,
+        max_gap=MAX_GAP,
+        angle_tolerance_degrees=2.0,
+        min_overlap_ratio=MIN_OVERLAP_RATIO,
+        min_overlap_length=MIN_OVERLAP_LENGTH,
+        canonical_line="midline",
+    )
+
+
+def _candidate_record(candidate: SharedWallCandidate) -> CandidateRecord:
+    return (
+        (candidate.first.room_id, candidate.first.segment_index),
+        (candidate.second.room_id, candidate.second.segment_index),
+        round(candidate.gap, 6),
+        round(candidate.overlap_length, 6),
+        round(candidate.overlap_ratio, 6),
+    )
+
+
+def _rejection_record(rejection: SharedWallRejection) -> RejectionRecord:
+    return (
+        (rejection.first.room_id, rejection.first.segment_index),
+        (rejection.second.room_id, rejection.second.segment_index),
+        rejection.reason,
+        rounded_optional(rejection.gap),
+        rounded_optional(rejection.overlap_length),
+        rounded_optional(rejection.overlap_ratio),
+        rejection.blocking_room_id,
+    )
+
+
+def _summary_record(summary: dict[str, Any]) -> RejectionRecord:
+    return (
+        (
+            cast("Hashable", summary["first_room_id"]),
+            int(summary["first_segment_index"]),
+        ),
+        (
+            cast("Hashable", summary["second_room_id"]),
+            int(summary["second_segment_index"]),
+        ),
+        str(summary["reason"]),
+        rounded_optional(summary["gap"]),
+        rounded_optional(summary["overlap_length"]),
+        rounded_optional(summary["overlap_ratio"]),
+        cast("Hashable | None", summary["blocking_room_id"]),
+    )
+
+
+@pytest.mark.parametrize(
+    "case",
+    regression_cases(),
+    ids=lambda case: case.name,
+)
+def test_floorplan_geometry_regression(case: FloorplanRegressionCase) -> None:
+    """Current extraction geometry and review diagnostics remain stable."""
+    detection = (
+        case.detection_factory()
+        if case.detection_factory is not None
+        else detect_shared_wall_candidates(case.rooms, _config())
+    )
+
+    result = normalise_shared_walls(case.rooms, _config(), detection)
+    if case.doors is not None:
+        result = attach_room_doors(result, case.doors)
+
+    applied = result.attrs["shared_wall_detection"]
+    assert sorted_records(_candidate_record(item) for item in applied.candidates) == (
+        sorted_records(case.expected_candidates)
+    )
+    assert sorted_records(_rejection_record(item) for item in applied.rejections) == (
+        sorted_records(case.expected_rejections)
+    )
+
+    assert len(result) == len(case.expected_geometry)
+    for actual, expected in zip(
+        result.geometry,
+        case.expected_geometry,
+        strict=True,
+    ):
+        assert_geometry_equal(actual, expected)
+
+    assert tuple(result["shared_wall_count"]) == case.expected_counts
+    assert tuple(result["shared_wall_review"]) == case.expected_review
+
+    for room_id, summaries in result["shared_wall_rejections"].items():
+        expected = [
+            rejection
+            for rejection in case.expected_rejections
+            if room_id in {rejection[0][0], rejection[1][0]}
+        ]
+        assert sorted_records(_summary_record(item) for item in summaries) == (
+            sorted_records(expected)
+        )
+
+    if case.expected_doors is not None:
+        actual_doors = tuple(
+            tuple(tuple(float(value) for value in door) for door in room_doors)
+            for room_doors in result["doors"]
+        )
+        assert actual_doors == case.expected_doors
+
+    if case.expected_door_report is not None:
+        actual_report = tuple(
+            (
+                str(item["EntityHandle"]),
+                int(item["attached_room_count"]),
+                bool(item["door_attachment_warning"]),
+            )
+            for item in result.attrs["door_attachment_report"]
+        )
+        assert actual_report == case.expected_door_report

--- a/python-code/tests/test_floorplan_regression.py
+++ b/python-code/tests/test_floorplan_regression.py
@@ -1,6 +1,6 @@
 """Regression baseline for floorplan geometry and diagnostics."""
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 import pytest
 
@@ -23,9 +23,6 @@ from tests.floorplan_regression_fixtures import (
     RejectionRecord,
     regression_cases,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Hashable
 
 MIN_GAP = 50.0
 MAX_GAP = 130.0

--- a/python-code/tests/test_floorplan_regression.py
+++ b/python-code/tests/test_floorplan_regression.py
@@ -1,6 +1,6 @@
 """Regression baseline for floorplan geometry and diagnostics."""
 
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -23,6 +23,9 @@ from tests.floorplan_regression_fixtures import (
     RejectionRecord,
     regression_cases,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Hashable
 
 MIN_GAP = 50.0
 MAX_GAP = 130.0

--- a/python-code/tests/test_shared_wall_spatial_index.py
+++ b/python-code/tests/test_shared_wall_spatial_index.py
@@ -1,0 +1,173 @@
+"""Tests for indexed shared-wall broad-phase selection."""
+
+from itertools import combinations
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Polygon
+
+from floorplan_extractor.shared_walls import (
+    REVIEW_REJECTION_REASONS,
+    SharedWallCandidate,
+    SharedWallConfig,
+    SharedWallDetectionResult,
+    SharedWallRejection,
+    _detect_shared_wall_candidates_exhaustive,
+    _extract_wall_segments,
+    _indexed_segment_pairs,
+    detect_shared_wall_candidates,
+)
+from tests.floorplan_regression_fixtures import (
+    FloorplanRegressionCase,
+    regression_cases,
+)
+
+
+def _config() -> SharedWallConfig:
+    return SharedWallConfig(
+        enabled=True,
+        min_gap=50.0,
+        max_gap=130.0,
+        angle_tolerance_degrees=2.0,
+        min_overlap_ratio=0.75,
+        min_overlap_length=250.0,
+        canonical_line="midline",
+    )
+
+
+def _candidate_signature(
+    candidate: SharedWallCandidate,
+) -> tuple[object, ...]:
+    return (
+        candidate.first.key,
+        candidate.second.key,
+        round(candidate.gap, 6),
+        round(candidate.overlap_length, 6),
+        round(candidate.overlap_ratio, 6),
+        tuple(round(value, 6) for value in candidate.overlap),
+    )
+
+
+def _rejection_signature(
+    rejection: SharedWallRejection,
+) -> tuple[object, ...]:
+    return (
+        rejection.first.key,
+        rejection.second.key,
+        rejection.reason,
+        None if rejection.gap is None else round(rejection.gap, 6),
+        (
+            None
+            if rejection.overlap_length is None
+            else round(rejection.overlap_length, 6)
+        ),
+        (
+            None
+            if rejection.overlap_ratio is None
+            else round(rejection.overlap_ratio, 6)
+        ),
+        rejection.blocking_room_id,
+    )
+
+
+def _material_signatures(
+    result: SharedWallDetectionResult,
+) -> tuple[list[tuple[object, ...]], list[tuple[object, ...]]]:
+    candidates = [_candidate_signature(candidate) for candidate in result.candidates]
+    rejections = [
+        _rejection_signature(rejection)
+        for rejection in result.rejections
+        if rejection.reason in REVIEW_REJECTION_REASONS
+    ]
+    return candidates, rejections
+
+
+def _room_grid(side_length: int) -> gpd.GeoDataFrame:
+    room_size = 400.0
+    stride = 500.0
+    polygons = [
+        Polygon(
+            [
+                (column * stride, row * stride),
+                (column * stride + room_size, row * stride),
+                (column * stride + room_size, row * stride + room_size),
+                (column * stride, row * stride + room_size),
+            ]
+        )
+        for row in range(side_length)
+        for column in range(side_length)
+    ]
+    return gpd.GeoDataFrame({"geometry": polygons}, geometry="geometry")
+
+
+@pytest.mark.parametrize(
+    "case",
+    regression_cases(),
+    ids=lambda case: case.name,
+)
+def test_indexed_detection_matches_exhaustive_regression_fixtures(
+    case: FloorplanRegressionCase,
+) -> None:
+    """Indexed detection preserves candidates and review-relevant rejections."""
+    indexed = detect_shared_wall_candidates(case.rooms, _config())
+    exhaustive = _detect_shared_wall_candidates_exhaustive(case.rooms, _config())
+
+    assert _material_signatures(indexed) == _material_signatures(exhaustive)
+
+
+@pytest.mark.parametrize("side_length", [2, 4, 6])
+def test_indexed_detection_matches_exhaustive_generated_grids(
+    side_length: int,
+) -> None:
+    """Generated layouts retain exhaustive narrow-phase outcomes."""
+    rooms = _room_grid(side_length)
+
+    indexed = detect_shared_wall_candidates(rooms, _config())
+    exhaustive = _detect_shared_wall_candidates_exhaustive(rooms, _config())
+
+    assert _material_signatures(indexed) == _material_signatures(exhaustive)
+
+
+def test_indexed_pairs_are_unique_cross_room_and_deterministic() -> None:
+    """Broad-phase pairs exclude self, duplicate, and same-room comparisons."""
+    rooms = _room_grid(3)
+    segments = _extract_wall_segments(rooms)
+    segment_positions = {
+        segment.key: position for position, segment in enumerate(segments)
+    }
+
+    first_run = _indexed_segment_pairs(segments, _config().max_gap)
+    second_run = _indexed_segment_pairs(segments, _config().max_gap)
+    first_keys = [(first.key, second.key) for first, second in first_run]
+    second_keys = [(first.key, second.key) for first, second in second_run]
+
+    assert first_keys == second_keys
+    assert len(first_keys) == len(set(first_keys))
+    assert all(first.room_id != second.room_id for first, second in first_run)
+    assert all(
+        segment_positions[first.key] < segment_positions[second.key]
+        for first, second in first_run
+    )
+
+
+def test_indexed_detection_result_order_is_deterministic() -> None:
+    """Repeated indexed detections retain candidate and rejection ordering."""
+    rooms = _room_grid(4)
+
+    first = detect_shared_wall_candidates(rooms, _config())
+    second = detect_shared_wall_candidates(rooms, _config())
+
+    assert _material_signatures(first) == _material_signatures(second)
+
+
+def test_indexed_broad_phase_reduces_generated_pair_count() -> None:
+    """A separated grid selects substantially fewer pairs than exhaustive search."""
+    rooms = _room_grid(8)
+    segments = _extract_wall_segments(rooms)
+    exhaustive_pair_count = sum(
+        first.room_id != second.room_id for first, second in combinations(segments, 2)
+    )
+
+    indexed_pairs = _indexed_segment_pairs(segments, _config().max_gap)
+
+    assert len(indexed_pairs) < exhaustive_pair_count / 4

--- a/python-code/tests/test_shared_walls.py
+++ b/python-code/tests/test_shared_walls.py
@@ -4,12 +4,17 @@ from itertools import pairwise
 
 import geopandas as gpd
 import pytest
-from shapely.geometry import Polygon
+from shapely.geometry import LineString, Polygon
 
 from floorplan_extractor.dxf_polygon_extraction import SharedWallConfig
 from floorplan_extractor.shared_walls import (
+    SharedWallCandidate,
+    SharedWallDetectionResult,
+    WallSegment,
+    _repair_normalised_polygon,
     detect_shared_wall_candidates,
     normalise_shared_walls,
+    rejection_overlap_lines,
 )
 from floorplan_extractor.yaml_construction import FlowList, polygons_to_rooms
 
@@ -96,6 +101,28 @@ def test_detect_shared_wall_candidates_rejects_insufficient_overlap() -> None:
     )
 
 
+def test_detect_shared_wall_candidates_flags_too_close_parallel_walls() -> None:
+    """Parallel wall faces below the configured gap are visible diagnostics."""
+    rooms = _rooms(
+        _room(0.0, 0.0, 400.0, 400.0),
+        _room(430.0, 0.0, 830.0, 400.0),
+    )
+
+    detection = detect_shared_wall_candidates(rooms, _config())
+    normalised = normalise_shared_walls(rooms, _config(), detection)
+
+    assert detection.candidates == []
+    assert any(
+        rejection.reason == "gap_too_small" and rejection.gap == pytest.approx(30.0)
+        for rejection in detection.rejections
+    )
+    assert normalised["shared_wall_review"].to_list() == [True, True]
+    assert any(
+        rejection["reason"] == "gap_too_small"
+        for rejection in normalised["shared_wall_rejections"].iloc[0]
+    )
+
+
 def test_detect_shared_wall_candidates_rejects_third_room_intersection() -> None:
     """Candidate wall faces are rejected when another room occupies the strip."""
     rooms = _rooms(
@@ -126,6 +153,53 @@ def test_detect_shared_wall_candidates_rejects_ambiguous_matches() -> None:
 
     assert result.candidates == []
     assert sum(r.reason == "ambiguous_match" for r in result.rejections) == 2
+
+
+def test_detect_shared_wall_candidates_allows_disjoint_matches_on_long_wall() -> None:
+    """A long corridor wall can match multiple non-overlapping room walls."""
+    rooms = _rooms(
+        _room(0.0, 0.0, 1000.0, 400.0),
+        _room(0.0, 500.0, 400.0, 900.0),
+        _room(600.0, 500.0, 1000.0, 900.0),
+    )
+
+    result = detect_shared_wall_candidates(rooms, _config())
+    normalised = normalise_shared_walls(rooms, _config(), result)
+
+    assert len(result.candidates) == 2
+    assert not any(r.reason == "ambiguous_match" for r in result.rejections)
+    assert normalised["shared_wall_count"].to_list() == [2, 1, 1]
+    assert tuple(sorted(((0.0, 450.0), (400.0, 450.0)))) in _canonical_segments(
+        normalised.geometry.iloc[0]
+    )
+    assert tuple(sorted(((600.0, 450.0), (1000.0, 450.0)))) in _canonical_segments(
+        normalised.geometry.iloc[0]
+    )
+
+
+def test_detect_shared_wall_candidates_aggregates_partial_wall_coverage() -> None:
+    """Disjoint partial matches are accepted when they jointly cover a wall."""
+    rooms = _rooms(
+        _room(0.0, 0.0, 400.0, 1000.0),
+        _room(500.0, -250.0, 900.0, 400.0),
+        _room(500.0, 600.0, 900.0, 1250.0),
+    )
+
+    result = detect_shared_wall_candidates(rooms, _config())
+    normalised = normalise_shared_walls(rooms, _config(), result)
+
+    assert len(result.candidates) == 2
+    assert not any(
+        rejection.reason == "insufficient_overlap_ratio"
+        for rejection in result.rejections
+    )
+    assert normalised["shared_wall_count"].to_list() == [2, 1, 1]
+    assert tuple(sorted(((450.0, 0.0), (450.0, 400.0)))) in _canonical_segments(
+        normalised.geometry.iloc[0]
+    )
+    assert tuple(sorted(((450.0, 600.0), (450.0, 1000.0)))) in _canonical_segments(
+        normalised.geometry.iloc[0]
+    )
 
 
 def test_detect_shared_wall_candidates_does_not_mutate_rooms() -> None:
@@ -165,6 +239,37 @@ def test_normalise_shared_walls_moves_accepted_pair_to_shared_midline() -> None:
     assert normalised["shared_wall_review"].to_list() == [False, False]
 
 
+def test_normalise_shared_walls_uses_one_projection_axis_for_skewed_pair() -> None:
+    """Slightly skewed reversed walls retain their real-world coordinates."""
+    rooms = _rooms(
+        Polygon(
+            [
+                (0.0, 0.0),
+                (5000.0, 0.0),
+                (5000.0, 400.0),
+                (0.0, 400.0),
+            ]
+        ),
+        Polygon(
+            [
+                (0.0, 500.0),
+                (5000.0, 500.01),
+                (5000.0, 900.0),
+                (0.0, 900.0),
+            ]
+        ),
+    )
+    detection = detect_shared_wall_candidates(rooms, _config())
+
+    normalised = normalise_shared_walls(rooms, _config(), detection)
+
+    assert len(detection.candidates) == 1
+    shared_segments = _canonical_segments(normalised.geometry.iloc[0]) & (
+        _canonical_segments(normalised.geometry.iloc[1])
+    )
+    assert shared_segments == {((0.0, 450.0), (5000.0, 450.005))}
+
+
 def test_normalise_shared_walls_leaves_rejected_candidates_unchanged() -> None:
     """Rejected detections remain diagnostic and do not alter geometry."""
     rooms = _rooms(
@@ -199,6 +304,155 @@ def test_normalise_shared_walls_leaves_ambiguous_candidates_unchanged() -> None:
     assert any(r.reason == "ambiguous_match" for r in detection.rejections)
     assert normalised.geometry.to_wkt().to_list() == original_wkt
     assert normalised["shared_wall_count"].to_list() == [0, 0, 0]
+
+
+def test_normalise_shared_walls_rejects_pair_that_invalidates_geometry() -> None:
+    """A failed pair is rejected without rolling back unrelated rooms."""
+    rooms = _rooms(
+        _room(0.0, 0.0, 1000.0, 100.0),
+        _room(600.0, -200.0, 1000.0, -100.0),
+    )
+    first = WallSegment(
+        room_id=0,
+        segment_index=2,
+        line=LineString([(1000.0, 100.0), (0.0, 100.0)]),
+        start=(1000.0, 100.0),
+        end=(0.0, 100.0),
+        length=1000.0,
+        angle_radians=0.0,
+    )
+    second = WallSegment(
+        room_id=1,
+        segment_index=2,
+        line=LineString([(1000.0, -100.0), (600.0, -100.0)]),
+        start=(1000.0, -100.0),
+        end=(600.0, -100.0),
+        length=400.0,
+        angle_radians=0.0,
+    )
+    candidate = SharedWallCandidate(
+        first=first,
+        second=second,
+        gap=200.0,
+        overlap_length=400.0,
+        overlap_ratio=1.0,
+        overlap=(600.0, 1000.0),
+        first_interval=(0.0, 400.0),
+        second_interval=(0.0, 400.0),
+        strip=Polygon(
+            [
+                (600.0, 100.0),
+                (1000.0, 100.0),
+                (1000.0, -100.0),
+                (600.0, -100.0),
+            ]
+        ),
+    )
+    detection = SharedWallDetectionResult(candidates=[candidate], rejections=[])
+    original_wkt = rooms.geometry.to_wkt().to_list()
+
+    normalised = normalise_shared_walls(rooms, _config(), detection)
+    applied = normalised.attrs["shared_wall_detection"]
+
+    assert normalised.geometry.to_wkt().to_list() == original_wkt
+    assert applied.candidates == []
+    assert applied.rejections[0].reason == "normalisation_invalid_geometry"
+    assert normalised["shared_wall_count"].to_list() == [0, 0]
+    assert normalised["shared_wall_review"].to_list() == [True, True]
+
+
+def test_normalise_shared_walls_collapses_near_duplicate_vertices() -> None:
+    """Numerical DXF slivers do not invalidate an otherwise safe rewrite."""
+    rooms = _rooms(
+        _room(0.0, 0.0, 1950.0, 400.0),
+        Polygon(
+            [
+                (2050.0 + 4e-9, 0.0),
+                (2050.0, 0.0),
+                (4000.0, 0.0),
+                (4000.0, 400.0),
+                (2050.0, 400.0),
+            ]
+        ),
+    )
+    detection = detect_shared_wall_candidates(rooms, _config())
+
+    normalised = normalise_shared_walls(rooms, _config(), detection)
+    applied = normalised.attrs["shared_wall_detection"]
+
+    assert len(applied.candidates) == 1
+    assert not any(
+        rejection.reason == "normalisation_invalid_geometry"
+        for rejection in applied.rejections
+    )
+    assert all(normalised.geometry.is_valid)
+
+
+def test_repair_normalised_polygon_removes_zero_area_line_artifact() -> None:
+    """A single polygon plus a retraced line is repaired conservatively."""
+    polygon = Polygon(
+        [
+            (0.0, 0.0),
+            (10.0, 0.0),
+            (10.0, 10.0),
+            (0.0, 10.0),
+            (0.0, 0.0),
+            (-5.0, 0.0),
+            (0.0, 0.0),
+        ]
+    )
+
+    repaired = _repair_normalised_polygon(polygon, [])
+
+    assert repaired is not None
+    assert repaired.is_valid
+    assert repaired.area == pytest.approx(100.0)
+
+
+def test_repair_normalised_polygon_rejects_multiple_polygon_parts() -> None:
+    """A repair that would split a room into multiple polygons is rejected."""
+    bow_tie = Polygon(
+        [
+            (0.0, 0.0),
+            (10.0, 10.0),
+            (0.0, 10.0),
+            (10.0, 0.0),
+            (0.0, 0.0),
+        ]
+    )
+
+    assert _repair_normalised_polygon(bow_tie, []) is None
+
+
+def test_rejection_overlap_lines_clip_source_segments() -> None:
+    """Rejected diagnostics show only the paired projected overlap."""
+    rooms = _rooms(
+        _room(0.0, 0.0, 400.0, 400.0),
+        _room(500.0, 300.0, 900.0, 700.0),
+    )
+    detection = detect_shared_wall_candidates(rooms, _config())
+    rejection = next(
+        rejection
+        for rejection in detection.rejections
+        if rejection.reason == "insufficient_overlap_length"
+    )
+
+    first, second = rejection_overlap_lines(rejection)
+
+    assert first.length == pytest.approx(100.0)
+    assert second.length == pytest.approx(100.0)
+    for actual, expected in zip(
+        sorted(first.coords),
+        [(400.0, 300.0), (400.0, 400.0)],
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(
+        sorted(second.coords),
+        [(500.0, 300.0), (500.0, 400.0)],
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected)
 
 
 def test_normalised_shared_walls_keep_yaml_wall_schema() -> None:

--- a/python-code/tests/test_shared_walls.py
+++ b/python-code/tests/test_shared_walls.py
@@ -1,0 +1,124 @@
+"""Tests for shared-wall candidate detection."""
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Polygon
+
+from floorplan_extractor.dxf_polygon_extraction import SharedWallConfig
+from floorplan_extractor.shared_walls import detect_shared_wall_candidates
+
+MIN_GAP = 50.0
+MAX_GAP = 130.0
+MIN_OVERLAP_LENGTH = 250.0
+MIN_OVERLAP_RATIO = 0.75
+
+
+def _config() -> SharedWallConfig:
+    return SharedWallConfig(
+        enabled=True,
+        min_gap=MIN_GAP,
+        max_gap=MAX_GAP,
+        angle_tolerance_degrees=2.0,
+        min_overlap_ratio=MIN_OVERLAP_RATIO,
+        min_overlap_length=MIN_OVERLAP_LENGTH,
+        canonical_line="midline",
+    )
+
+
+def _room(
+    min_x: float,
+    min_y: float,
+    max_x: float,
+    max_y: float,
+) -> Polygon:
+    return Polygon(
+        [
+            (min_x, min_y),
+            (max_x, min_y),
+            (max_x, max_y),
+            (min_x, max_y),
+        ]
+    )
+
+
+def _rooms(*polygons: Polygon) -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame({"geometry": list(polygons)}, geometry="geometry")
+
+
+def test_detect_shared_wall_candidates_accepts_parallel_overlapping_gap() -> None:
+    """Parallel wall faces with enough overlap and gap are candidates."""
+    rooms = _rooms(
+        _room(0.0, 0.0, 400.0, 400.0),
+        _room(500.0, 0.0, 900.0, 400.0),
+    )
+
+    result = detect_shared_wall_candidates(rooms, _config())
+
+    assert len(result.candidates) == 1
+    candidate = result.candidates[0]
+    assert candidate.gap == pytest.approx(100.0)
+    assert candidate.overlap_length == pytest.approx(400.0)
+    assert candidate.overlap_ratio == pytest.approx(1.0)
+    assert not any(r.reason == "ambiguous_match" for r in result.rejections)
+
+
+def test_detect_shared_wall_candidates_rejects_insufficient_overlap() -> None:
+    """Parallel wall faces with too little projected overlap are rejected."""
+    rooms = _rooms(
+        _room(0.0, 0.0, 400.0, 400.0),
+        _room(500.0, 300.0, 900.0, 700.0),
+    )
+
+    result = detect_shared_wall_candidates(rooms, _config())
+
+    assert result.candidates == []
+    assert any(
+        rejection.reason == "insufficient_overlap_length"
+        and rejection.overlap_length == pytest.approx(100.0)
+        for rejection in result.rejections
+    )
+
+
+def test_detect_shared_wall_candidates_rejects_third_room_intersection() -> None:
+    """Candidate wall faces are rejected when another room occupies the strip."""
+    rooms = _rooms(
+        _room(0.0, 0.0, 400.0, 400.0),
+        _room(500.0, 0.0, 900.0, 400.0),
+        _room(425.0, 100.0, 475.0, 200.0),
+    )
+
+    result = detect_shared_wall_candidates(rooms, _config())
+
+    assert result.candidates == []
+    assert any(
+        rejection.reason == "third_room_intersection"
+        and rejection.blocking_room_id == 2
+        for rejection in result.rejections
+    )
+
+
+def test_detect_shared_wall_candidates_rejects_ambiguous_matches() -> None:
+    """One-to-many wall-face matches are reported as ambiguous."""
+    rooms = _rooms(
+        _room(0.0, 0.0, 400.0, 400.0),
+        _room(500.0, 0.0, 900.0, 400.0),
+        _room(500.0, 0.0, 900.0, 400.0),
+    )
+
+    result = detect_shared_wall_candidates(rooms, _config())
+
+    assert result.candidates == []
+    assert sum(r.reason == "ambiguous_match" for r in result.rejections) == 2
+
+
+def test_detect_shared_wall_candidates_does_not_mutate_rooms() -> None:
+    """Candidate detection leaves input geometries unchanged."""
+    rooms = _rooms(
+        _room(0.0, 0.0, 400.0, 400.0),
+        _room(500.0, 0.0, 900.0, 400.0),
+    )
+    original_wkt = rooms.geometry.to_wkt().to_list()
+
+    detect_shared_wall_candidates(rooms, _config())
+
+    assert rooms.geometry.to_wkt().to_list() == original_wkt

--- a/python-code/tests/test_shared_walls.py
+++ b/python-code/tests/test_shared_walls.py
@@ -1,11 +1,17 @@
 """Tests for shared-wall candidate detection."""
 
+from itertools import pairwise
+
 import geopandas as gpd
 import pytest
 from shapely.geometry import Polygon
 
 from floorplan_extractor.dxf_polygon_extraction import SharedWallConfig
-from floorplan_extractor.shared_walls import detect_shared_wall_candidates
+from floorplan_extractor.shared_walls import (
+    detect_shared_wall_candidates,
+    normalise_shared_walls,
+)
+from floorplan_extractor.yaml_construction import FlowList, polygons_to_rooms
 
 MIN_GAP = 50.0
 MAX_GAP = 130.0
@@ -43,6 +49,17 @@ def _room(
 
 def _rooms(*polygons: Polygon) -> gpd.GeoDataFrame:
     return gpd.GeoDataFrame({"geometry": list(polygons)}, geometry="geometry")
+
+
+def _canonical_segments(polygon: Polygon) -> set[tuple[tuple[float, float], ...]]:
+    segments = set()
+    coords = list(polygon.exterior.coords)
+    for start, end in pairwise(coords):
+        start_xy = (round(start[0], 6), round(start[1], 6))
+        end_xy = (round(end[0], 6), round(end[1], 6))
+        segments.add(tuple(sorted((start_xy, end_xy))))
+
+    return segments
 
 
 def test_detect_shared_wall_candidates_accepts_parallel_overlapping_gap() -> None:
@@ -122,3 +139,88 @@ def test_detect_shared_wall_candidates_does_not_mutate_rooms() -> None:
     detect_shared_wall_candidates(rooms, _config())
 
     assert rooms.geometry.to_wkt().to_list() == original_wkt
+
+
+def test_normalise_shared_walls_moves_accepted_pair_to_shared_midline() -> None:
+    """Accepted paired wall faces are replaced with identical midline segments."""
+    rooms = _rooms(
+        _room(0.0, 0.0, 400.0, 400.0),
+        _room(500.0, 0.0, 900.0, 400.0),
+    )
+    detection = detect_shared_wall_candidates(rooms, _config())
+
+    normalised = normalise_shared_walls(rooms, _config(), detection)
+
+    expected_midline = ((450.0, 0.0), (450.0, 400.0))
+    room_a_segments = _canonical_segments(normalised.geometry.iloc[0])
+    room_b_segments = _canonical_segments(normalised.geometry.iloc[1])
+
+    assert tuple(sorted(expected_midline)) in room_a_segments
+    assert tuple(sorted(expected_midline)) in room_b_segments
+    assert normalised.geometry.iloc[0].is_valid
+    assert normalised.geometry.iloc[1].is_valid
+    assert normalised.geometry.iloc[0].area > 0
+    assert normalised.geometry.iloc[1].area > 0
+    assert normalised["shared_wall_count"].to_list() == [1, 1]
+    assert normalised["shared_wall_review"].to_list() == [False, False]
+
+
+def test_normalise_shared_walls_leaves_rejected_candidates_unchanged() -> None:
+    """Rejected detections remain diagnostic and do not alter geometry."""
+    rooms = _rooms(
+        _room(0.0, 0.0, 400.0, 400.0),
+        _room(500.0, 300.0, 900.0, 700.0),
+    )
+    original_wkt = rooms.geometry.to_wkt().to_list()
+    detection = detect_shared_wall_candidates(rooms, _config())
+
+    normalised = normalise_shared_walls(rooms, _config(), detection)
+
+    assert detection.candidates == []
+    assert normalised.geometry.to_wkt().to_list() == original_wkt
+    assert normalised["shared_wall_count"].to_list() == [0, 0]
+    assert normalised["shared_wall_review"].to_list() == [True, True]
+    assert all(normalised["shared_wall_rejections"].apply(bool))
+
+
+def test_normalise_shared_walls_leaves_ambiguous_candidates_unchanged() -> None:
+    """Ambiguous candidate groups are not normalised."""
+    rooms = _rooms(
+        _room(0.0, 0.0, 400.0, 400.0),
+        _room(500.0, 0.0, 900.0, 400.0),
+        _room(500.0, 0.0, 900.0, 400.0),
+    )
+    original_wkt = rooms.geometry.to_wkt().to_list()
+    detection = detect_shared_wall_candidates(rooms, _config())
+
+    normalised = normalise_shared_walls(rooms, _config(), detection)
+
+    assert detection.candidates == []
+    assert any(r.reason == "ambiguous_match" for r in detection.rejections)
+    assert normalised.geometry.to_wkt().to_list() == original_wkt
+    assert normalised["shared_wall_count"].to_list() == [0, 0, 0]
+
+
+def test_normalised_shared_walls_keep_yaml_wall_schema() -> None:
+    """Normalised geometry still serialises to [x1, y1, x2, y2] wall lists."""
+    rooms = gpd.GeoDataFrame(
+        {
+            "room_name": ["Room A", "Room B"],
+            "geometry": [
+                _room(0.0, 0.0, 400.0, 400.0),
+                _room(500.0, 0.0, 900.0, 400.0),
+            ],
+        },
+        geometry="geometry",
+    )
+    detection = detect_shared_wall_candidates(rooms, _config())
+    normalised = normalise_shared_walls(rooms, _config(), detection)
+
+    serialised_rooms = polygons_to_rooms(normalised, "room_name")
+
+    assert len(serialised_rooms) == 2
+    assert all(
+        isinstance(wall, FlowList) and len(wall) == 4
+        for room in serialised_rooms
+        for wall in room["walls"]
+    )


### PR DESCRIPTION
## Summary

This PR adds a configurable workflow for converting labelled DXF floorplans into YAML geometry.

The extraction pipeline now supports the following:

- polygonising room boundary linework from DXF files;
- selecting and normalising rooms labels for a configured floor;
- applying explicit polygon splits, additions, and merges for known CAD gaps;
- detecting and normalising shared wall faces onto a common midline;
- projecting CAD door symbols onto final room boundaries;
- serialising labelled rooms into the existing wall and door YAML schema.

The floorplan extaction example has also been expanded into a usable command line workflow which accepts input, config, output and diagnostic paths, writing the generated building YAML and producing a diagnostic image showing labelled rooms and canonical door opening.

The PR adds documentation for the floorplan extraction process, API docs entries for the extractor modules, shared-wall diagnostics guidance, and a standalone synthetic shared-wall benchmark.

Closes #118 

## Implementation notes

The main extraction changes are in `floorplan_extractor`:

- `dxf_polygon_extraction.py` now parses optional configuration for shared walls, polygon splits, polygon additions, and polygon merges.
- `shared_walls.py` introduces shared-wall candidate detection, rejection diagnostics, and conservative normalisation of accepted wall pairs.
- `yaml_construction.py` continues to emit the existing room wall and door segment schema, including normalised shared-wall geometry.

Shared-wall handling is deliberately conservative. Candidate wall faces must pass gap, angle, overlap length, and overlap ratio checks. Matches are rejected when another room occupies the wall strip, when the match is ambiguous, or when normalising the pair would invalidate room geometry. Review-relevant decisions are retained in the returned GeoDataFrame metadata.

Door handling now projects CAD door symbols onto the final room boundaries, so the generated YAML contains canonical zero-thickness door openings rather than raw CAD symbol geometry. Shared openings are attached to both connected rooms where possible.
